### PR TITLE
Add Configuration and Platform command-line arguments

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen/Program.Arguments.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.Arguments.cs
@@ -36,8 +36,7 @@ Example: -bl:output.binlog;ProjectImports=ZipFile")]
             "-c|--configuration",
             CommandOptionType.MultipleValue,
             ValueName = "values",
-            Description = @"Specifies one or more Configuration values to use when generating the solution.  By default, your projects are read to determine these values but in some cases you may want to specify them.",
-            ShowInHelpText = false)]
+            Description = @"Specifies one or more Configuration values to use when generating the solution.")]
         public string[] Configuration { get; set; }
 
         /// <summary>
@@ -160,8 +159,7 @@ Examples:
             "--platform",
             CommandOptionType.MultipleValue,
             ValueName = "values",
-            Description = @"Specifies one or more Platform values to use when generating the solution.  By default, your projects are read to determine these values but in some cases you may want to specify them.",
-            ShowInHelpText = false)]
+            Description = @"Specifies one or more Platform values to use when generating the solution.")]
         public string[] Platform { get; set; }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.SlnGen/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.cs
@@ -149,7 +149,11 @@ namespace Microsoft.VisualStudio.SlnGen
                 }
             }
 
-            SlnFile solution = new SlnFile();
+            SlnFile solution = new SlnFile
+            {
+                Platforms = Platform ?? Array.Empty<string>(),
+                Configurations = Configuration ?? Array.Empty<string>(),
+            };
 
             solution.AddProjects(projects, customProjectTypeGuids, project.FullPath);
 


### PR DESCRIPTION
Allows users to specify which configuration and platforms will be available at the solution level.  Projects are still read and the best mapping available is made.

Fixes #99 