### PR TITLE
Update existing solution but re-use solution GUID and project GUID

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.cs
@@ -155,6 +155,16 @@ namespace Microsoft.VisualStudio.SlnGen
                 Configurations = Configuration ?? Array.Empty<string>(),
             };
 
+            if (SlnFile.TryParseExistingSolution(SolutionFileFullPath, out Guid solutionGuid, out IReadOnlyDictionary<string, Guid> projectGuidsByPath))
+            {
+                logger.LogMessageNormal("Updating existing solution file and reusing Visual Studio cache");
+
+                solution.SolutionGuid = solutionGuid;
+                solution.ExistingProjectGuids = projectGuidsByPath;
+
+                ShouldLoadProjectsInVisualStudio = true;
+            }
+
             solution.AddProjects(projects, customProjectTypeGuids, project.FullPath);
 
             solution.AddSolutionItems(solutionItems);

--- a/src/Microsoft.VisualStudio.SlnGen/SlnFile.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnFile.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace Microsoft.VisualStudio.SlnGen
 {
@@ -16,9 +17,39 @@ namespace Microsoft.VisualStudio.SlnGen
     public sealed class SlnFile
     {
         /// <summary>
+        /// The beginning of the line that ends a global section.
+        /// </summary>
+        private const string GlobalSectionEnd = "\tEndGlobalSection";
+
+        /// <summary>
+        /// The beginning of the line that starts the extensibility global section.
+        /// </summary>
+        private const string GlobalSectionStartExtensibilityGlobals = "\tGlobalSection(ExtensibilityGlobals)";
+
+        /// <summary>
         /// The solution header.
         /// </summary>
         private const string Header = "Microsoft Visual Studio Solution File, Format Version {0}";
+
+        /// <summary>
+        /// The beginning of the line that ends project information.
+        /// </summary>
+        private const string ProjectSectionEnd = "EndProject";
+
+        /// <summary>
+        /// The beginning of the line that contains project information.
+        /// </summary>
+        private const string ProjectSectionStart = "Project(\"";
+
+        /// <summary>
+        /// The beginning of the line that contains the solution GUID.
+        /// </summary>
+        private const string SectionSettingSolutionGuid = "\t\tSolutionGuid = ";
+
+        /// <summary>
+        /// The separator to split project information by.
+        /// </summary>
+        private static readonly string[] ProjectSectionSeparator = { "\", \"" };
 
         /// <summary>
         /// The file format version.
@@ -58,9 +89,19 @@ namespace Microsoft.VisualStudio.SlnGen
         public IReadOnlyCollection<string> Configurations { get; set; }
 
         /// <summary>
+        /// Gets or sets a <see cref="IReadOnlyDictionary{TKey,TValue}" /> containing any existing project GUIDs to re-use.
+        /// </summary>
+        public IReadOnlyDictionary<string, Guid> ExistingProjectGuids { get; set; }
+
+        /// <summary>
         /// Gets or sets a <see cref="IReadOnlyCollection{String}" /> of Platform values to use.
         /// </summary>
         public IReadOnlyCollection<string> Platforms { get; set; }
+
+        /// <summary>
+        /// Gets or sets a <see cref="Guid" /> for the solution file.
+        /// </summary>
+        public Guid SolutionGuid { get; set; } = Guid.NewGuid();
 
         /// <summary>
         /// Gets a list of solution items.
@@ -68,20 +109,124 @@ namespace Microsoft.VisualStudio.SlnGen
         public IReadOnlyCollection<string> SolutionItems => _solutionItems;
 
         /// <summary>
+        /// Attempts to read the existing GUID from a solution file if one exists.
+        /// </summary>
+        /// <param name="path">The path to a solution file.</param>
+        /// <param name="solutionGuid">Receives the <see cref="Guid" /> of the existing solution file if one is found, otherwise default(Guid).</param>
+        /// <param name="projectGuidsByPath">Receives the project GUIDs by their full paths.</param>
+        /// <returns>true if the solution GUID was found, otherwise false.</returns>
+        public static bool TryParseExistingSolution(string path, out Guid solutionGuid, out IReadOnlyDictionary<string, Guid> projectGuidsByPath)
+        {
+            solutionGuid = default;
+            projectGuidsByPath = default;
+
+            bool foundSolutionGuid = false;
+
+            Dictionary<string, Guid> projectGuids = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
+
+            FileInfo fileInfo = new FileInfo(path);
+
+            if (!fileInfo.Exists || fileInfo.Directory == null)
+            {
+                return false;
+            }
+
+            string solutionFileDirectory = fileInfo.Directory.FullName;
+
+            using (FileStream stream = File.OpenRead(path))
+            using (StreamReader reader = new StreamReader(stream, Encoding.GetEncoding(0), detectEncodingFromByteOrderMarks: true))
+            {
+                string line;
+
+                while ((line = reader.ReadLine()) != null)
+                {
+                    if (line.StartsWith(ProjectSectionStart))
+                    {
+                        string[] projectDetails = line.Split(ProjectSectionSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+                        if (projectDetails.Length == 3)
+                        {
+                            FileInfo projectFullPath = new FileInfo(Path.Combine(solutionFileDirectory, projectDetails[1].Trim().Trim('\"')));
+
+                            if (projectFullPath.Exists && Guid.TryParse(projectDetails[2].Trim('\"'), out Guid projectGuid))
+                            {
+                                projectGuids[projectFullPath.FullName] = projectGuid;
+                            }
+                        }
+
+                        while ((line = reader.ReadLine()) != null)
+                        {
+                            if (line.StartsWith(ProjectSectionEnd))
+                            {
+                                break;
+                            }
+                        }
+                    }
+
+                    if (line != null && line.StartsWith(GlobalSectionStartExtensibilityGlobals))
+                    {
+                        while ((line = reader.ReadLine()) != null)
+                        {
+                            if (line.StartsWith(SectionSettingSolutionGuid))
+                            {
+                                string solutionGuidString = line.Substring(SectionSettingSolutionGuid.Length);
+
+                                foundSolutionGuid = Guid.TryParse(solutionGuidString, out solutionGuid);
+                            }
+
+                            if (line.StartsWith(GlobalSectionEnd))
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            projectGuidsByPath = projectGuids;
+
+            return foundSolutionGuid;
+        }
+
+        /// <summary>
         /// Adds the specified projects.
         /// </summary>
         /// <param name="projects">An <see cref="IEnumerable{SlnProject}"/> containing projects to add to the solution.</param>
         public void AddProjects(IEnumerable<SlnProject> projects)
         {
-            _projects.AddRange(projects);
+            _projects.AddRange(projects.Select(project =>
+            {
+                if (project != null && ExistingProjectGuids != null && ExistingProjectGuids.TryGetValue(project.FullPath, out Guid projectGuid))
+                {
+                    project.ProjectGuid = projectGuid;
+                }
+
+                return project;
+            }));
         }
 
+        /// <summary>
+        /// Adds the specified projects to the solution file.
+        /// </summary>
+        /// <param name="projects">An <see cref="IEnumerable{T}" /> of projects to add.</param>
+        /// <param name="customProjectTypeGuids">An <see cref="IReadOnlyDictionary{TKey,TValue}" /> containing any custom project type GUIDs to use.</param>
+        /// <param name="mainProjectFullPath">The full path to the main project.</param>
         public void AddProjects(IEnumerable<Project> projects, IReadOnlyDictionary<string, Guid> customProjectTypeGuids, string mainProjectFullPath)
         {
             _projects.AddRange(
                 projects
                     .Distinct(new EqualityComparer<Project>((x, y) => string.Equals(x.FullPath, y.FullPath, StringComparison.OrdinalIgnoreCase), i => i.FullPath.GetHashCode()))
-                    .Select(i => SlnProject.FromProject(i, customProjectTypeGuids, string.Equals(i.FullPath, mainProjectFullPath, StringComparison.OrdinalIgnoreCase)))
+                    .Select(i =>
+                    {
+                        SlnProject project = SlnProject.FromProject(i, customProjectTypeGuids, string.Equals(i.FullPath, mainProjectFullPath, StringComparison.OrdinalIgnoreCase));
+
+                        if (project != null && ExistingProjectGuids != null && ExistingProjectGuids.TryGetValue(project.FullPath, out Guid projectGuid))
+                        {
+                            project.ProjectGuid = projectGuid;
+                        }
+
+                        return project;
+                    })
                     .Where(i => i != null)
                     .OrderBy(i => i.FullPath));
         }
@@ -115,6 +260,11 @@ namespace Microsoft.VisualStudio.SlnGen
             }
         }
 
+        /// <summary>
+        /// Saves the Visual Studio solution to a file.
+        /// </summary>
+        /// <param name="writer">The <see cref="TextWriter" /> to save the solution file to.</param>
+        /// <param name="useFolders">Specifies if folders should be created.</param>
         internal void Save(TextWriter writer, bool useFolders)
         {
             writer.WriteLine(Header, _fileFormatVersion);
@@ -203,7 +353,7 @@ namespace Microsoft.VisualStudio.SlnGen
                 {
                     foreach (string platform in solutionPlatforms)
                     {
-                        var foundPlatform = TryGetProjectSolutionPlatform(platform, project, out string projectSolutionPlatform, out string projectBuildPlatform);
+                        bool foundPlatform = TryGetProjectSolutionPlatform(platform, project, out string projectSolutionPlatform, out string projectBuildPlatform);
 
                         writer.WriteLine($@"		{projectGuid}.{configuration}|{platform}.ActiveCfg = {configuration}|{projectSolutionPlatform}");
 
@@ -227,10 +377,32 @@ namespace Microsoft.VisualStudio.SlnGen
             writer.WriteLine("	EndGlobalSection");
 
             writer.WriteLine("	GlobalSection(ExtensibilityGlobals) = postSolution");
-            writer.WriteLine($"		SolutionGuid = {Guid.NewGuid().ToSolutionString()}");
+            writer.WriteLine($"		SolutionGuid = {SolutionGuid.ToSolutionString()}");
             writer.WriteLine("	EndGlobalSection");
 
             writer.WriteLine("EndGlobal");
+        }
+
+        private IEnumerable<string> GetValidSolutionPlatforms(IEnumerable<string> platforms)
+        {
+            List<string> values = platforms
+                .Select(i => i.ToSolutionPlatform())
+                .Where(platform =>
+                {
+                    switch (platform.ToLowerInvariant())
+                    {
+                        case "any cpu":
+                        case "x64":
+                        case "x86":
+                            return true;
+
+                        default:
+                            return false;
+                    }
+                }).OrderBy(i => i)
+                .ToList();
+
+            return values.Any() ? values : new List<string> { "Any CPU" };
         }
 
         private bool TryGetProjectSolutionPlatform(string solutionPlatform, SlnProject project, out string projectSolutionPlatform, out string projectBuildPlatform)
@@ -348,28 +520,6 @@ namespace Microsoft.VisualStudio.SlnGen
             projectSolutionPlatform = project.Platforms.First().ToSolutionPlatform();
 
             return false;
-        }
-
-        private IEnumerable<string> GetValidSolutionPlatforms(IEnumerable<string> platforms)
-        {
-            List<string> values = platforms
-                .Select(i => i.ToSolutionPlatform())
-                .Where(platform =>
-                {
-                    switch (platform.ToLowerInvariant())
-                    {
-                        case "any cpu":
-                        case "x64":
-                        case "x86":
-                            return true;
-
-                        default:
-                            return false;
-                    }
-                }).OrderBy(i => i)
-                .ToList();
-
-            return values.Any() ? values : new List<string> { "Any CPU" };
         }
     }
 }


### PR DESCRIPTION
Parse existing solution and rewrite it with the same solution and project GUIDs so that Visual Studio will re-use its cache.  Also enable project loading assuming that the solution was loaded once already.

Fixes #104 