### PR TITLE
Fix how values for Configuration and Platform are parsed from the command-line arguments

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/ArgumentsTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/ArgumentsTests.cs
@@ -24,6 +24,24 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
             console.Output.ShouldContain("Usage: ", console.Output);
         }
 
+        [Fact]
+        public void GetConfigurations()
+        {
+            new Program
+            {
+                Configuration = new[] { "One", "Two;Three,one,Four", "four" },
+            }.GetConfigurations().ShouldBe(new[] { "One", "Two", "Three", "Four" });
+        }
+
+        [Fact]
+        public void GetPlatforms()
+        {
+            new Program
+            {
+                Platform = new[] { "Five", "Six;Seven,five,Eight", "eight" },
+            }.GetPlatforms().ShouldBe(new[] { "Five", "Six", "Seven", "Eight" });
+        }
+
         [Theory]
         [InlineData("--nologo")]
         [InlineData("/nologo")]

--- a/src/Microsoft.VisualStudio.SlnGen/ExtensionMethods.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ExtensionMethods.cs
@@ -152,22 +152,28 @@ namespace Microsoft.VisualStudio.SlnGen
         /// <summary>
         /// Splits the specified values.
         /// </summary>
-        /// <param name="values">An array of strings containing comma or semicolon delimited values.</param>
-        /// <returns>An <see cref="IEnumerable{String}" /> containing the split values.</returns>
-        public static IEnumerable<string> SplitValues(this string[] values)
+        /// <param name="source">An <see cref="IEnumerable{T}" /> containing comma or semicolon delimited values.</param>
+        /// <returns>An <see cref="IReadOnlyCollection{String}" /> containing the split values.</returns>
+        public static IReadOnlyCollection<string> SplitValues(this IEnumerable<string> source)
         {
-            if (values == null)
+            if (source == null)
             {
-                yield break;
+                return Array.Empty<string>();
             }
 
-            foreach (string value in values)
+            HashSet<string> values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (string item in source)
             {
-                foreach (string item in value.Split(ArgumentSplitChars, StringSplitOptions.RemoveEmptyEntries))
+                foreach (string value in item.Split(ArgumentSplitChars, StringSplitOptions.RemoveEmptyEntries)
+                    .Where(i => !string.IsNullOrWhiteSpace(i))
+                    .Select(i => i.Trim()))
                 {
-                    yield return item.Trim();
+                    values.Add(value.Trim());
                 }
             }
+
+            return values;
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.SlnGen/Program.Arguments.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.Arguments.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 
 using McMaster.Extensions.CommandLineUtils;
+using System.Collections.Generic;
 
 namespace Microsoft.VisualStudio.SlnGen
 {
@@ -223,5 +224,17 @@ You must disable shell execute when using this command-line option.
             Description = @"Display this amount of information in the event log.  The available verbosity levels are:
   q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].")]
         public string Verbosity { get; set; }
+
+        /// <summary>
+        /// Gets the Configuration values based on what was specified as command-line arguments.
+        /// </summary>
+        /// <returns>An <see cref="IReadOnlyCollection{T}" /> containing the unique values for Configuration.</returns>
+        public IReadOnlyCollection<string> GetConfigurations() => Configuration.SplitValues();
+
+        /// <summary>
+        /// Gets the Platform values based on what was specified as command-line arguments.
+        /// </summary>
+        /// <returns>An <see cref="IReadOnlyCollection{T}" /> containing the unique values for Platform.</returns>
+        public IReadOnlyCollection<string> GetPlatforms() => Platform.SplitValues();
     }
 }

--- a/src/Microsoft.VisualStudio.SlnGen/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.cs
@@ -151,8 +151,8 @@ namespace Microsoft.VisualStudio.SlnGen
 
             SlnFile solution = new SlnFile
             {
-                Platforms = Platform ?? Array.Empty<string>(),
-                Configurations = Configuration ?? Array.Empty<string>(),
+                Platforms = GetPlatforms(),
+                Configurations = GetConfigurations(),
             };
 
             if (SlnFile.TryParseExistingSolution(SolutionFileFullPath, out Guid solutionGuid, out IReadOnlyDictionary<string, Guid> projectGuidsByPath))


### PR DESCRIPTION
Properly split values by semicolon and comma