### PR TITLE
Fix crash on MSBuild 15

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -46,7 +46,19 @@
           BeforeTargets="_GetBuildOutputFilesWithTfm"
           DependsOnTargets="ResolveReferences">
     <ItemGroup>
-      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('AssetType', 'runtime'))" />
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('AssetType', 'runtime'))"
+                            TargetPath="$(TargetFramework)\%(Filename)%(Extension)" />
+
+      <BuiltProjectOutputGroupOutput Update="@(BuiltProjectOutputGroupOutput)"
+                                     TargetPath="$(TargetFramework)\%(Filename)%(Extension)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="Foo"
+          AfterTargets="_WalkEachTargetPerFramework">
+    <ItemGroup>
+      <_TargetPathsToSymbols Update="@(_TargetPathsToSymbols)"
+                             TargetPath="%(TargetFramework)%(Filename)%(Extension)" />
     </ItemGroup>
   </Target>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -54,11 +54,11 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="Foo"
+  <Target Name="UpdateSymbolsPackagePath"
           AfterTargets="_WalkEachTargetPerFramework">
     <ItemGroup>
       <_TargetPathsToSymbols Update="@(_TargetPathsToSymbols)"
-                             TargetPath="%(TargetFramework)%(Filename)%(Extension)" />
+                             TargetPath="%(TargetFramework)\%(Filename)%(Extension)" />
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.VisualStudio.SlnGen/App.config
+++ b/src/Microsoft.VisualStudio.SlnGen/App.config
@@ -15,35 +15,5 @@
     <gcServer enabled="true" />
     <Thread_UseAllCpuGroups enabled="true" />
     <ThrowUnobservedTaskExceptions enabled="true" />
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.3.0" newVersion="1.2.3.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Interactive.Async" publicKeyToken="94bc3704cddfc263" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.IO.Abstractions" publicKeyToken="96bf224d23c43e59" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.3.0" newVersion="1.4.3.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.6.3.0" newVersion="4.6.3.0" />
-      </dependentAssembly>
-    </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net46;net472</TargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.config</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludeReferenceCopyLocalPathsInBuildOutputInPackage>true</IncludeReferenceCopyLocalPathsInBuildOutputInPackage>
     <IsTool>true</IsTool>
@@ -11,16 +11,24 @@
   <Import Project="Shared.props" />
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Locator" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Runtime" ExcludeAssets="Runtime" IncludeAssets="None" PrivateAssets="All" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+    <PackageReference Include="Microsoft.Build" VersionOverride="15.9.20" ExcludeAssets="Runtime" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Runtime" VersionOverride="15.9.20" ExcludeAssets="Runtime" IncludeAssets="None" PrivateAssets="All" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" VersionOverride="15.9.20" ExcludeAssets="Runtime" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="Runtime" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Runtime" ExcludeAssets="Runtime" IncludeAssets="None" PrivateAssets="All" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Win32.Registry" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net472\MSBuild.exe" Private="false" />
+    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\$(TargetFramework)\MSBuild.exe" Private="false" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/src/Microsoft.VisualStudio.SlnGen/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.cs
@@ -101,8 +101,13 @@ namespace Microsoft.VisualStudio.SlnGen
                 remoteLoggers: null,
                 toolsetDefinitionLocations: ToolsetDefinitionLocations.Default,
                 maxNodeCount: 1,
+#if NET46
+                onlyLogCriticalEvents: false))
+#else
+
                 onlyLogCriticalEvents: false,
                 loadProjectsReadOnly: true))
+#endif
             {
                 LoadProjects(projectCollection, logger);
 

--- a/src/Microsoft.VisualStudio.SlnGen/ProjectLoading/ProjectGraphProjectLoader.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ProjectLoading/ProjectGraphProjectLoader.cs
@@ -2,6 +2,7 @@
 //
 // Licensed under the MIT license.
 
+#if !NET46
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Evaluation.Context;
@@ -61,3 +62,4 @@ namespace Microsoft.VisualStudio.SlnGen.ProjectLoading
         }
     }
 }
+#endif

--- a/src/Microsoft.VisualStudio.SlnGen/ProjectLoading/ProjectLoaderFactory.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ProjectLoading/ProjectLoaderFactory.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.SlnGen.ProjectLoading
         /// <returns>An <see cref="IProjectLoader" /> object that can be used to load MSBuild projects.</returns>
         public static IProjectLoader Create(string msbuildExePath, ISlnGenLogger logger)
         {
+#if !NET46
             FileVersionInfo fileVersionInfo = FileVersionInfo.GetVersionInfo(msbuildExePath);
 
             // MSBuild 16.4 and above use the Static Graph API
@@ -26,6 +27,7 @@ namespace Microsoft.VisualStudio.SlnGen.ProjectLoading
             {
                 return new ProjectGraphProjectLoader(msbuildExePath);
             }
+#endif
 
             return new LegacyProjectLoader(logger);
         }

--- a/src/Microsoft.VisualStudio.SlnGen/Tasks/Microsoft.VisualStudio.SlnGen.targets
+++ b/src/Microsoft.VisualStudio.SlnGen/Tasks/Microsoft.VisualStudio.SlnGen.targets
@@ -8,7 +8,12 @@
           Condition="'$(CustomBeforeSlnGenTargets)' != '' and Exists('$(CustomBeforeSlnGenTargets)')" />
 
   <UsingTask TaskName="Microsoft.VisualStudio.SlnGen.Tasks.SlnGenToolTask"
-             AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\slngen.exe'))" />
+             AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\net46\slngen.exe'))"
+             Condition="'$(MSBuildToolsVersion)' != 'Current'" />
+
+  <UsingTask TaskName="Microsoft.VisualStudio.SlnGen.Tasks.SlnGenToolTask"
+             AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\net472\slngen.exe'))"
+             Condition="'$(MSBuildToolsVersion)' == 'Current'" />
 
   <Target Name="SlnGen"
           Condition="'$(MSBuildRuntimeType)' == 'Full'"


### PR DESCRIPTION
Target net46 and older MSBuild
Add some preprocessor code to ensure compatibility
Remove binding redirects

Fixes #116