### PR TITLE
Build only solution configurations that exist

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
@@ -61,13 +61,24 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 ProjectTypeGuid = Guid.NewGuid(),
             };
 
+            SlnProject projectE = new SlnProject
+            {
+                Configurations = new[] { "Release" },
+                FullPath = GetTempFileName(),
+                IsMainProject = true,
+                Name = "ProjectE",
+                Platforms = new[] { "AnyCPU" },
+                ProjectGuid = Guid.NewGuid(),
+                ProjectTypeGuid = Guid.NewGuid(),
+            };
+
             SlnFile slnFile = new SlnFile()
             {
                 Configurations = new[] { "Debug" },
                 Platforms = new[] { "Any CPU" },
             };
 
-            slnFile.AddProjects(new[] { projectA, projectB, projectC, projectD });
+            slnFile.AddProjects(new[] { projectA, projectB, projectC, projectD, projectE });
 
             string solutionFilePath = GetTempFileName();
 
@@ -82,6 +93,8 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
             ValidateSolutionPlatformAndConfiguration(projectC, solutionFile, "Debug", "amd64");
 
             ValidateSolutionPlatformAndConfiguration(projectD, solutionFile, "Debug", "Razzle", expectedIncludeInBuild: false);
+
+            ValidateSolutionPlatformAndConfiguration(projectE, solutionFile, "Release", "AnyCPU", expectedIncludeInBuild: false);
         }
 
         [Fact]


### PR DESCRIPTION
Fixed sln generation so it doesn't build projects that don't have a configuration matching the solution cofiguration This should help support conditionally building projects based on their configuration.