### PR TITLE
Added a --solutiondir command line switch.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ slngen [switches] [project]
 | <code>--loadprojects:true&#124;false</code> | | When launching Visual Studio, opens the specified solution without loading any projects. Default: `true` |
 | <code>--useshellexecute:true&#124;false</code> | <code>-u:true&#124;false</code> | Indicates whether or not the Visual Studio solution file should be opened by the registered file extension handler. Default: `true` |
 | <code>--solutionfile:path</code> | `-o:file` | An optional path to the solution file to generate. Defaults to the same directory as the project. |
+| <code>--solutiondir:path</code> | `-d:path` | An optional path to the directory in which the solution file will be generated.  Defaults to the same directory as the project. --solutionfile will take precedence over this switch. |
 | <code>--devenvpath:path</code> | | Specifies a full path to Visual Studio's devenv.exe to use when opening the solution file. By default, SlnGen will launch the program associated with the .sln file extension. |
 | <code>--property:name=value</code> | `-p:name=value` | Set or override these project-level properties. Use a semicolon or a comma to separate multiple properties, or specify each property separately.|
 | <code>--configuration:value</code> | | (Optional) Specifies one or more values to use for the solution Configuration (i.e. Debug or Release).  By default, all projects' available values for Configuration are used.  In certain cases, projects do not properly convey the Configuration so it is desirable to generate a solution with your own values. |

--- a/src/Microsoft.VisualStudio.SlnGen/Program.Arguments.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.Arguments.cs
@@ -217,6 +217,15 @@ Examples:
         public string[] SolutionFileFullPath { get; set; }
 
         /// <summary>
+        /// Gets or sets the full path to the solution file to generate.
+        /// </summary>
+        [Option(
+            "-d|--solutiondir <path>",
+            CommandOptionType.MultipleValue,
+            Description = "An optional path to the directory in which the solution file will be generated.  Defaults to the same directory as the project. --solutionfile will take precedence over this switch.")]
+        public string[] SolutionDirectoryFullPath { get; set; }
+
+        /// <summary>
         /// Gets or sets the verbosity to use.
         /// </summary>
         [Option(

--- a/src/Microsoft.VisualStudio.SlnGen/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.cs
@@ -166,7 +166,16 @@ namespace Microsoft.VisualStudio.SlnGen
 
             if (solutionFileFullPath.IsNullOrWhiteSpace())
             {
-                solutionFileFullPath = Path.ChangeExtension(project.FullPath, ".sln");
+                string solutionDirectoryFullPath = SolutionDirectoryFullPath?.LastOrDefault();
+
+                if (solutionDirectoryFullPath.IsNullOrWhiteSpace())
+                {
+                    solutionDirectoryFullPath = project.DirectoryPath;
+                }
+
+                string solutionFileName = Path.ChangeExtension(Path.GetFileName(project.FullPath), "sln");
+
+                solutionFileFullPath = Path.Combine(solutionDirectoryFullPath, solutionFileName);
             }
 
             logger.LogMessageHigh($"Generating Visual Studio solution \"{solutionFileFullPath}\" ...");
@@ -360,6 +369,7 @@ namespace Microsoft.VisualStudio.SlnGen
                 ["ProjectEvaluationCount"] = _projectEvaluationCount.ToString(),
                 ["ProjectEvaluationMilliseconds"] = _projectEvaluationMilliseconds.ToString(),
                 ["SolutionFileFullPathSpecified"] = (!SolutionFileFullPath?.LastOrDefault().IsNullOrWhiteSpace()).ToString(),
+                ["SolutionDirectoryFullPathSpecified"] = (!SolutionDirectoryFullPath?.LastOrDefault().IsNullOrWhiteSpace()).ToString(),
                 ["SolutionItemCount"] = _solutionItemCount.ToString(),
                 ["UseBinaryLogger"] = BinaryLogger.HasValue.ToString(),
                 ["UseFileLogger"] = FileLoggerParameters.HasValue.ToString(),


### PR DESCRIPTION
Added a --solutiondir command line switch to configure the directory in which the solution file will be generated. The solution file is named based on the name of project in the source directory as before.

The --solutionfile will take precedence over this switch, so if the user provides a value for --solutionfile this will be an absolute path to the sln file and thus we dont use the --solutiondir