### PR TITLE
Disable ShellExecute for Corext

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.cs
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.SlnGen
 
                     string devEnvFullPath = _arguments.DevEnvFullPath?.LastOrDefault();
 
-                    if (!enableShellExecute || !loadProjectsInVisualStudio)
+                    if (!enableShellExecute || !loadProjectsInVisualStudio || IsCorext)
                     {
                         if (_instance == null)
                         {
@@ -192,7 +192,7 @@ namespace Microsoft.VisualStudio.SlnGen
                         devEnvFullPath = Path.Combine(_instance.InstallationPath, "Common7", "IDE", "devenv.exe");
                     }
 
-                    VisualStudioLauncher.Launch(solutionFileFullPath, enableShellExecute, loadProjectsInVisualStudio, devEnvFullPath, forwardingLogger);
+                    VisualStudioLauncher.Launch(solutionFileFullPath, loadProjectsInVisualStudio, devEnvFullPath, forwardingLogger);
                 }
 
                 LogTelemetry(evaluationTime, evaluationCount, customProjectTypeGuidCount, solutionItemCount);

--- a/src/Microsoft.VisualStudio.SlnGen/VisualStudioLauncher.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/VisualStudioLauncher.cs
@@ -20,11 +20,10 @@ namespace Microsoft.VisualStudio.SlnGen
         /// Launches Visual Studio.
         /// </summary>
         /// <param name="solutionFileFullPath">The full path to the solution file.</param>
-        /// <param name="useShellExecute">A value indicating whether to use shell execute.</param>
         /// <param name="loadProjects">A value indicating whether to load projects in Visual Studio.</param>
         /// <param name="devEnvFullPath">An optional full path to devenv.exe.</param>
         /// <param name="logger">A <see cref="ISlnGenLogger" /> to use for logging.</param>
-        public static void Launch(string solutionFileFullPath, bool useShellExecute, bool loadProjects, string devEnvFullPath, ISlnGenLogger logger)
+        public static void Launch(string solutionFileFullPath, bool loadProjects, string devEnvFullPath, ISlnGenLogger logger)
         {
             if (solutionFileFullPath.IsNullOrWhiteSpace())
             {
@@ -47,6 +46,7 @@ namespace Microsoft.VisualStudio.SlnGen
                 processStartInfo = new ProcessStartInfo
                 {
                     FileName = devEnvFullPath,
+                    UseShellExecute = false,
                 };
 
                 commandLineBuilder.AppendFileNameIfNotNull(solutionFileFullPath);


### PR DESCRIPTION
Visual Studio must inherit environment variables so it has to be launched via devenv.exe instead of the default handler for .sln files.