### PR TITLE
Added an option for collapsing the folder structure

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ slngen [switches] [project]
 | <code>--help</code> | <code>-?</code> | Show help information |
 | <code>--launch:true&#124;false</code> | | Launch Visual Studio after generating the Solution file. Default: `true` |
 | <code>--folders:true&#124;false</code> | | Enables the creation of hierarchical solution folders. Default: `false` |
+| <code>--collapsefolders:true&#124;false</code> | | Enables folders containing a single item to be collapsed into their parent folder. Default: `false` |
 | <code>--loadprojects:true&#124;false</code> | | When launching Visual Studio, opens the specified solution without loading any projects. Default: `true` |
 | <code>--useshellexecute:true&#124;false</code> | <code>-u:true&#124;false</code> | Indicates whether or not the Visual Studio solution file should be opened by the registered file extension handler. Default: `true` |
 | <code>--solutionfile:path</code> | `-o:file` | An optional path to the solution file to generate. Defaults to the same directory as the project. |

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnHierarchyTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnHierarchyTests.cs
@@ -16,50 +16,19 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         [Fact]
         public void HierarchyIsCorrectlyFormed()
         {
-            List<SlnProject> projects = new List<SlnProject>
-            {
-                new SlnProject
-                {
-                    FullPath = @"D:\zoo\foo\bar\baz\baz.csproj",
-                    Name = "baz",
-                    ProjectGuid = Guid.NewGuid(),
-                    ProjectTypeGuid = SlnProject.DefaultLegacyProjectTypeGuid,
-                },
-                new SlnProject
-                {
-                    FullPath = @"D:\zoo\foo\bar\baz1\baz1.csproj",
-                    Name = "baz1",
-                    ProjectGuid = Guid.NewGuid(),
-                    ProjectTypeGuid = SlnProject.DefaultLegacyProjectTypeGuid,
-                },
-                new SlnProject
-                {
-                    FullPath = @"D:\zoo\foo\bar\baz2\baz2.csproj",
-                    Name = "baz2",
-                    ProjectGuid = Guid.NewGuid(),
-                    ProjectTypeGuid = SlnProject.DefaultLegacyProjectTypeGuid,
-                },
-                new SlnProject
-                {
-                    FullPath = @"D:\zoo\foo\bar1\bar1.csproj",
-                    Name = "bar1",
-                    ProjectGuid = Guid.NewGuid(),
-                    ProjectTypeGuid = SlnProject.DefaultLegacyProjectTypeGuid,
-                },
-            };
+            DummyFolder root = DummyFolder.CreateRoot(@"D:\zoo\foo");
+            DummyFolder bar = root.AddSubDirectory("bar");
+            bar.AddProjectWithDirectory("baz");
+            bar.AddProjectWithDirectory("baz1");
+            bar.AddProjectWithDirectory("baz2");
+            root.AddProjectWithDirectory("bar1");
+
+            List<SlnProject> projects = root.GetAllProjects();
 
             SlnHierarchy hierarchy = new SlnHierarchy(projects);
 
-            hierarchy.Folders.Select(i => i.FullPath)
-                .ShouldBe(new[]
-                {
-                    @"D:\zoo\foo\bar\baz",
-                    @"D:\zoo\foo\bar\baz1",
-                    @"D:\zoo\foo\bar\baz2",
-                    @"D:\zoo\foo\bar",
-                    @"D:\zoo\foo\bar1",
-                    @"D:\zoo\foo",
-                });
+            hierarchy.Folders.Select(i => i.FullPath).OrderBy(s => s)
+                .ShouldBe(root.GetAllFolders().Select(f => f.FullPath).OrderBy(s => s));
 
             foreach (SlnProject project in projects)
             {
@@ -68,6 +37,133 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                     .First(i => i.FullPath.Equals(Path.GetDirectoryName(project.FullPath)))
                     .Projects.ShouldHaveSingleItem()
                     .ShouldBe(project);
+            }
+        }
+
+        [Fact]
+        public void HierarchyWithCollapsedFoldersIsCorrectlyFormed()
+        {
+            DummyFolder root = DummyFolder.CreateRoot(@"D:\zoo\foo");
+            DummyFolder bar = root.AddSubDirectory("bar");
+            DummyFolder qux = bar.AddSubDirectory("qux");
+            SlnProject baz = qux.AddProjectWithDirectory("baz");
+            SlnProject baz1 = qux.AddProjectWithDirectory("baz1");
+            SlnProject baz2 = qux.AddProjectWithDirectory("baz2");
+            SlnProject bar1 = root.AddProjectWithDirectory("bar1");
+            SlnProject baz3 = root
+                .AddSubDirectory("foo1")
+                .AddSubDirectory("foo2")
+                .AddProjectWithDirectory("baz3");
+
+            DummyFolder rootExpected = DummyFolder.CreateRoot(@"D:\zoo\foo");
+            DummyFolder barQuxExpected = rootExpected.AddSubDirectory($"bar {SlnHierarchy.Separator} qux");
+            barQuxExpected.Projects.Add(baz);
+            barQuxExpected.Projects.Add(baz1);
+            barQuxExpected.Projects.Add(baz2);
+            rootExpected.Projects.Add(bar1);
+            rootExpected.AddSubDirectory($"foo1 {SlnHierarchy.Separator} foo2 {SlnHierarchy.Separator} baz3").Projects.Add(baz3);
+
+            SlnHierarchy hierarchy = new SlnHierarchy(root.GetAllProjects(), collapseFolders: true);
+
+            SlnFolder[] resultFolders = hierarchy.Folders.OrderBy(f => f.FullPath).ToArray();
+            DummyFolder[] expectedFolders = rootExpected.GetAllFolders().OrderBy(f => f.FullPath).ToArray();
+
+            resultFolders.Length.ShouldBe(expectedFolders.Length);
+
+            for (int i = 0; i < resultFolders.Length; i++)
+            {
+                SlnFolder resultFolder = resultFolders[i];
+                DummyFolder expectedFolder = expectedFolders[i];
+
+                resultFolder.Name.ShouldBe(expectedFolder.Name);
+
+                // Verify that expected and results projects match
+                resultFolder.Projects.Count.ShouldBe(expectedFolder.Projects.Count);
+                resultFolder.Projects.ShouldAllBe(p => expectedFolder.Projects.Contains(p));
+
+                // Verify that expected and results child folders match
+                resultFolder.Folders.Count.ShouldBe(expectedFolder.Folders.Count);
+                resultFolder.Folders.ShouldAllBe(p => expectedFolder.Folders.Exists(f => f.Name == p.Name));
+            }
+        }
+
+        private class DummyFolder
+        {
+            private DummyFolder(string path)
+            {
+                FileInfo fileInfo = new FileInfo(path);
+
+                this.Folders = new List<DummyFolder>();
+                this.Projects = new List<SlnProject>();
+
+                this.FullPath = path;
+                this.Name = fileInfo.Name;
+            }
+
+            public string FullPath { get; }
+
+            public List<DummyFolder> Folders { get; }
+
+            public List<SlnProject> Projects { get; }
+
+            public string Name { get; }
+
+            public static DummyFolder CreateRoot(string rootPath)
+            {
+                return new DummyFolder(rootPath);
+            }
+
+            public List<SlnProject> GetAllProjects()
+            {
+                List<SlnProject> projects = this.Folders
+                    .SelectMany(f => f.GetAllProjects())
+                    .ToList();
+
+                projects.AddRange(this.Projects);
+
+                return projects;
+            }
+
+            public List<DummyFolder> GetAllFolders()
+            {
+                List<DummyFolder> folders = this.Folders
+                    .SelectMany(f => f.GetAllFolders())
+                    .ToList();
+
+                folders.Add(this);
+
+                return folders;
+            }
+
+            public DummyFolder AddSubDirectory(string folderName)
+            {
+                string path = Path.Combine(this.FullPath, folderName);
+
+                DummyFolder childFolder = new DummyFolder(path);
+
+                this.Folders.Add(childFolder);
+
+                return childFolder;
+            }
+
+            public SlnProject AddProject(string name)
+            {
+                SlnProject project = new SlnProject
+                {
+                    FullPath = Path.Combine(this.FullPath, name) + ".csproj",
+                    Name = name,
+                    ProjectGuid = Guid.NewGuid(),
+                    ProjectTypeGuid = SlnProject.DefaultLegacyProjectTypeGuid,
+                };
+
+                this.Projects.Add(project);
+
+                return project;
+            }
+
+            public SlnProject AddProjectWithDirectory(string name)
+            {
+                return this.AddSubDirectory(name).AddProject(name);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.SlnGen/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.cs
@@ -290,7 +290,7 @@ namespace Microsoft.VisualStudio.SlnGen
 
             solution.AddSolutionItems(solutionItems);
 
-            solution.Save(solutionFileFullPath, _arguments.EnableFolders());
+            solution.Save(solutionFileFullPath, _arguments.EnableFolders(), _arguments.EnableCollapseFolders());
 
             return (solutionFileFullPath, customProjectTypeGuids.Count, solutionItems.Count);
         }
@@ -447,6 +447,7 @@ namespace Microsoft.VisualStudio.SlnGen
                     ["DevEnvFullPathSpecified"] = (!_arguments.DevEnvFullPath?.LastOrDefault().IsNullOrWhiteSpace()).ToString(),
                     ["EntryProjectCount"] = _arguments.Projects?.Length.ToString(),
                     ["Folders"] = _arguments.EnableFolders().ToString(),
+                    ["CollapseFolders"] = _arguments.EnableCollapseFolders().ToString(),
                     ["IsCoreXT"] = IsCorext.ToString(),
                     ["IsNetCore"] = IsNetCore.ToString(),
                     ["LaunchVisualStudio"] = _arguments.ShouldLaunchVisualStudio().ToString(),

--- a/src/Microsoft.VisualStudio.SlnGen/ProgramArguments.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ProgramArguments.cs
@@ -35,6 +35,16 @@ Example: -bl:output.binlog;ProjectImports=ZipFile")]
         public (bool HasValue, string Arguments) BinaryLogger { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not folders containing a single item should be collapsed into their parent folder.
+        /// </summary>
+        [Option(
+            "--collapsefolders",
+            CommandOptionType.MultipleValue,
+            ValueName = "true",
+            Description = "Enables folders containing a single item to be collapsed into their parent folder.  Default: false")]
+        public string[] CollapseFolders { get; set; }
+
+        /// <summary>
         /// Gets or sets the configurations to use when generating the solution.
         /// </summary>
         [Option(
@@ -239,6 +249,8 @@ Examples:
         public string[] Verbosity { get; set; }
 
         public bool EnableFolders() => GetBoolean(Folders);
+
+        public bool EnableCollapseFolders() => GetBoolean(CollapseFolders);
 
         public bool EnableShellExecute() => GetBoolean(ShellExecute, defaultValue: true);
 

--- a/src/Microsoft.VisualStudio.SlnGen/SlnFile.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnFile.cs
@@ -245,7 +245,8 @@ namespace Microsoft.VisualStudio.SlnGen
         /// </summary>
         /// <param name="path">The full path to the file to write to.</param>
         /// <param name="useFolders">Specifies if folders should be created.</param>
-        public void Save(string path, bool useFolders)
+        /// <param name="collapseFolders">An optional value indicating whether or not folders containing a single item should be collapsed into their parent folder.</param>
+        public void Save(string path, bool useFolders, bool collapseFolders = false)
         {
             string directoryName = Path.GetDirectoryName(path);
 
@@ -254,9 +255,10 @@ namespace Microsoft.VisualStudio.SlnGen
                 Directory.CreateDirectory(directoryName);
             }
 
-            using (StreamWriter writer = File.CreateText(path))
+            using (FileStream fileStream = File.Create(path))
+            using (StreamWriter writer = new StreamWriter(fileStream, Encoding.Unicode))
             {
-                Save(writer, useFolders);
+                Save(writer, useFolders, collapseFolders);
             }
         }
 
@@ -265,7 +267,8 @@ namespace Microsoft.VisualStudio.SlnGen
         /// </summary>
         /// <param name="writer">The <see cref="TextWriter" /> to save the solution file to.</param>
         /// <param name="useFolders">Specifies if folders should be created.</param>
-        internal void Save(TextWriter writer, bool useFolders)
+        /// <param name="collapseFolders">An optional value indicating whether or not folders containing a single item should be collapsed into their parent folder.</param>
+        internal void Save(TextWriter writer, bool useFolders, bool collapseFolders = false)
         {
             writer.WriteLine(Header, _fileFormatVersion);
 
@@ -292,7 +295,7 @@ namespace Microsoft.VisualStudio.SlnGen
 
             if (useFolders && _projects.Any(i => !i.IsMainProject))
             {
-                hierarchy = new SlnHierarchy(_projects);
+                hierarchy = new SlnHierarchy(_projects, collapseFolders);
 
                 foreach (SlnFolder folder in hierarchy.Folders)
                 {


### PR DESCRIPTION
Users can specify `--collapsefolders:true` to have the hierarchy leave out folders that only contain a single child.

Fixes #68 