### PR TITLE
Fix parsing of bad ProjectGuid

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.cs
@@ -216,6 +216,12 @@ namespace Microsoft.VisualStudio.SlnGen
                     {
                     }
                 }
+                catch (InvalidProjectFileException e)
+                {
+                    forwardingLogger.LogError(e.Message, e.ErrorCode, e.ProjectFile, e.LineNumber, e.ColumnNumber);
+
+                    return 1;
+                }
                 catch (Exception e)
                 {
                     forwardingLogger.LogError($"Unhandled exception: {e}");

--- a/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
@@ -234,7 +234,7 @@ namespace Microsoft.VisualStudio.SlnGen
                         columnNumber: 0,
                         endLineNumber: 0,
                         endColumnNumber: 0,
-                        message: $"The {MSBuildPropertyNames.ProjectGuid} property value \"{projectGuid}\" is not a valid GUID.",
+                        message: $"The {MSBuildPropertyNames.ProjectGuid} property value \"{projectGuidValue}\" is not a valid GUID.",
                         errorSubcategory: null,
                         errorCode: null,
                         helpKeyword: null);


### PR DESCRIPTION
A bad ProjectGuid is rejected with an unhandled exception.  Log an error and exit with a non-zero exit code instead.