### PR TITLE
Improve configuration and platform detection for C++ projects

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnProjectTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnProjectTests.cs
@@ -275,6 +275,50 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         }
 
         [Fact]
+        public void GetPlatformsAndConfigurationsFromCppProject()
+        {
+            Project project = ProjectCreator.Create()
+                .ItemInclude(
+                    "ProjectConfiguration",
+                    "ConfigA|PlatformA",
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["Configuration"] = "ConfigA",
+                        ["Platform"] = "PlatformA",
+                    })
+                .ItemInclude(
+                    "ProjectConfiguration",
+                    "ConfigA|PlatformB",
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["Configuration"] = "ConfigA",
+                        ["Platform"] = "PlatformB",
+                    })
+                .ItemInclude(
+                    "ProjectConfiguration",
+                    "ConfigB|PlatformA",
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["Configuration"] = "ConfigB",
+                        ["Platform"] = "PlatformA",
+                    })
+                .ItemInclude(
+                    "ProjectConfiguration",
+                    "ConfigB|PlatformB",
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["Configuration"] = "ConfigB",
+                        ["Platform"] = "PlatformB",
+                    })
+                .Save(GetTempFileName(".vcxproj"));
+
+            SlnProject slnProject = SlnProject.FromProject(project, new Dictionary<string, Guid>());
+
+            slnProject.Configurations.ShouldBe(new[] { "ConfigA", "ConfigB" });
+            slnProject.Platforms.ShouldBe(new[] { "PlatformA", "PlatformB" });
+        }
+
+        [Fact]
         public void UseFileName()
         {
             CreateAndValidateProject(expectedGuid: "{DE681393-7151-459D-862C-918CCD2CB371}");

--- a/src/Microsoft.VisualStudio.SlnGen/SlnFile.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnFile.cs
@@ -459,19 +459,27 @@ namespace Microsoft.VisualStudio.SlnGen
         {
             List<string> values = platforms
                 .Select(i => i.ToSolutionPlatform())
-                .Where(platform =>
+                .Select(platform =>
                 {
                     switch (platform.ToLowerInvariant())
                     {
                         case "any cpu":
                         case "x64":
                         case "x86":
-                            return true;
+                            return platform;
+
+                        case "amd64":
+                            return "x64";
+
+                        case "win32":
+                            return "x86";
 
                         default:
-                            return false;
+                            return null;
                     }
-                }).OrderBy(i => i)
+                })
+                .Where(i => i != null)
+                .OrderBy(i => i)
                 .ToList();
 
             return values.Any() ? values : new List<string> { "Any CPU" };

--- a/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
@@ -154,6 +154,26 @@ namespace Microsoft.VisualStudio.SlnGen
 
         internal static IReadOnlyList<string> GetConfigurations(Project project, string projectFileExtension, in bool isUsingMicrosoftNETSdk)
         {
+            if (string.Equals(projectFileExtension, ".vcxproj"))
+            {
+                HashSet<string> items = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (ProjectItem item in project.GetItems("ProjectConfiguration"))
+                {
+                    string configuration = item.GetMetadataValue("Configuration");
+
+                    if (!configuration.IsNullOrWhiteSpace())
+                    {
+                        items.Add(configuration);
+                    }
+                }
+
+                if (items.Any())
+                {
+                    return items.ToList();
+                }
+            }
+
             if (isUsingMicrosoftNETSdk)
             {
                 string value = project.GetPropertyValue("Configurations");
@@ -335,6 +355,26 @@ namespace Microsoft.VisualStudio.SlnGen
 
         private static IReadOnlyList<string> GetPlatforms(Project project, string projectFileExtension, bool isUsingMicrosoftNETSdk)
         {
+            if (string.Equals(projectFileExtension, ".vcxproj"))
+            {
+                HashSet<string> items = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (ProjectItem item in project.GetItems("ProjectConfiguration"))
+                {
+                    string platform = item.GetMetadataValue("Platform");
+
+                    if (!platform.IsNullOrWhiteSpace())
+                    {
+                        items.Add(platform);
+                    }
+                }
+
+                if (items.Any())
+                {
+                    return items.ToList();
+                }
+            }
+
             if (isUsingMicrosoftNETSdk)
             {
                 string value = project.GetPropertyValue("Platforms");
@@ -346,40 +386,6 @@ namespace Microsoft.VisualStudio.SlnGen
             }
 
             return project.GetPossiblePropertyValuesOrDefault("Platform", "Any CPU").ToList();
-        }
-
-        private static IEnumerable<string> GetPlatforms(Project project)
-        {
-            string platforms = project.GetPropertyValue("Platforms");
-
-            if (!platforms.IsNullOrWhiteSpace())
-            {
-                foreach (string value in platforms.Split(';'))
-                {
-                    if (string.Equals(value, "AnyCPU", StringComparison.OrdinalIgnoreCase))
-                    {
-                        yield return "Any CPU";
-                    }
-                    else
-                    {
-                        yield return value;
-                    }
-                }
-            }
-            else
-            {
-                foreach (string platform in project.GetPossiblePropertyValuesOrDefault("Platform", "Any CPU"))
-                {
-                    if (string.Equals(platform, "AnyCPU", StringComparison.OrdinalIgnoreCase))
-                    {
-                        yield return "Any CPU";
-                    }
-                    else
-                    {
-                        yield return platform;
-                    }
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
C++ projects declare ProjectConfiguration items to specify their supported platforms and configurations.  C++ projects also specify values like amd64 and Win32 which needs to be translated to x64 and x86.