### PR TITLE
Add option for projects to specify a solution folder

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -122,6 +122,7 @@ Use the following properties and items to customize the generated Solution file.
 | `IncludeInSolutionFile` | Indicates whether or not a project should be included in a generated Solution file.                               | `true` or `false` | `true` |
 | `SlnGenFolders`         | Indicates whether or not a hierarchy of folders should be created.  If `false`, the projects are in a flat list. | `true` or `false` | `true` |
 | `SlnGenIsDeployable`    | Indicates whether or not a project is considered deployable by Visual Studio.                                     | `true` or `false` | `false` <br />Service Fabric projects are automatically set to `true` |
+| `SlnGenSolutionFolder   | Specifies a solution folder to place the project in.  `SlnGenFolders` must be `false`.                            | | |
 
 | Item | Description |
 |------|-------------|

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
@@ -348,11 +348,20 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         {
             FileInfo solutionFilePath = new FileInfo(GetTempFileName());
 
-            FileInfo projectFilePath = new FileInfo(Path.Combine(solutionFilePath.DirectoryName!, @"src\Microsoft.VisualStudio.SlnGen\Microsoft.VisualStudio.SlnGen.csproj"));
+            Dictionary<string, Guid> projects = new Dictionary<string, Guid>
+            {
+                [@"src\Microsoft.VisualStudio.SlnGen\Microsoft.VisualStudio.SlnGen.csproj"] = new Guid("C8D336E5-9E65-4D34-BA9A-DB58936947CF"),
+                [@"test\Microsoft.VisualStudio.SlnGen.UnitTests\Microsoft.VisualStudio.SlnGen.UnitTests.csproj"] = new Guid("B55ACBF0-DC34-44BA-8535-8F81325B6D70"),
+            };
 
-            Directory.CreateDirectory(projectFilePath.DirectoryName!);
+            Dictionary<FileInfo, Guid> projectFiles = projects.ToDictionary(i => new FileInfo(Path.Combine(solutionFilePath.DirectoryName!, i.Key)), i => i.Value);
 
-            File.WriteAllText(projectFilePath.FullName, @"<Project />");
+            foreach (KeyValuePair<FileInfo, Guid> item in projectFiles)
+            {
+                Directory.CreateDirectory(item.Key.DirectoryName!);
+
+                File.WriteAllText(item.Key.FullName, @"<Project />");
+            }
 
             File.WriteAllText(
                 solutionFilePath.FullName,
@@ -362,6 +371,12 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 16.0.29011.400
 MinimumVisualStudioVersion = 10.0.40219.1
 Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Microsoft.VisualStudio.SlnGen"", ""src\Microsoft.VisualStudio.SlnGen\Microsoft.VisualStudio.SlnGen.csproj"", ""{C8D336E5-9E65-4D34-BA9A-DB58936947CF}""
+EndProject
+Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Microsoft.VisualStudio.SlnGen.UnitTests"", ""test\Microsoft.VisualStudio.SlnGen.UnitTests\Microsoft.VisualStudio.SlnGen.UnitTests.csproj"", ""{B55ACBF0-DC34-44BA-8535-8F81325B6D70}""
+EndProject
+Project(""{2150E333-8FDC-42A3-9474-1A3956D46DE8}"") = ""FolderA"", ""FolderA"", ""{9C915FE4-72A5-4368-8979-32B3983E6041}""
+EndProject
+Project(""{2150E333-8FDC-42A3-9474-1A3956D46DE8}"") = ""FolderB"", ""FolderB"", ""{D3A9F802-38CC-4F8D-8DE9-8DF9C8B7EADC}""
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -373,9 +388,17 @@ Global
 		{C8D336E5-9E65-4D34-BA9A-DB58936947CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8D336E5-9E65-4D34-BA9A-DB58936947CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8D336E5-9E65-4D34-BA9A-DB58936947CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B55ACBF0-DC34-44BA-8535-8F81325B6D70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B55ACBF0-DC34-44BA-8535-8F81325B6D70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B55ACBF0-DC34-44BA-8535-8F81325B6D70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B55ACBF0-DC34-44BA-8535-8F81325B6D70}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{C8D336E5-9E65-4D34-BA9A-DB58936947CF} = {9C915FE4-72A5-4368-8979-32B3983E6041}
+		{B55ACBF0-DC34-44BA-8535-8F81325B6D70} = {D3A9F802-38CC-4F8D-8DE9-8DF9C8B7EADC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CFFC4187-96EE-4465-B5B3-0BAFD3C14BB6}
@@ -386,10 +409,7 @@ EndGlobal
 
             solutionGuid.ShouldBe(Guid.Parse("CFFC4187-96EE-4465-B5B3-0BAFD3C14BB6"));
 
-            projectGuidsByPath.ShouldBe(new List<KeyValuePair<string, Guid>>
-            {
-                new KeyValuePair<string, Guid>(projectFilePath.FullName, Guid.Parse("{C8D336E5-9E65-4D34-BA9A-DB58936947CF}")),
-            });
+            projectGuidsByPath.ShouldBe(projectFiles.Select(i => new KeyValuePair<string, Guid>(i.Key.FullName, i.Value)));
         }
 
         [Fact]
@@ -534,6 +554,54 @@ EndGlobal
                     slnProject.ParentProjectGuid.ShouldNotBeNull();
                 }
             }
+        }
+
+        [Fact]
+        public void ProjectSolutionFolders()
+        {
+            string root = Path.GetTempPath();
+            string projectName1 = Path.GetFileName(Path.GetTempFileName());
+            string projectName2 = Path.GetFileName(Path.GetTempFileName());
+            string projectName3 = Path.GetFileName(Path.GetTempFileName());
+            Project[] projects =
+            {
+                new Project
+                {
+                    FullPath = Path.Combine(root, "SubFolder1", "Project1", projectName1),
+                },
+                new Project
+                {
+                    FullPath = Path.Combine(root, "SubFolder1", "Project2", projectName2),
+                },
+                new Project
+                {
+                    FullPath = Path.Combine(root, "SubFolder2", "Project3", projectName3),
+                },
+            };
+
+            projects[0].SetProperty(MSBuildPropertyNames.SlnGenSolutionFolder, "FolderA");
+            projects[1].SetProperty(MSBuildPropertyNames.SlnGenSolutionFolder, "FolderB");
+
+            string solutionFilePath = GetTempFileName();
+
+            SlnFile slnFile = new SlnFile();
+
+            slnFile.AddProjects(projects, new Dictionary<string, Guid>(), projects[1].FullPath);
+            slnFile.Save(solutionFilePath, useFolders: false);
+
+            SolutionFile s = SolutionFile.Parse(solutionFilePath);
+
+            ProjectInSolution project1 = s.ProjectsByGuid.FirstOrDefault(i => i.Value.ProjectName.Equals(Path.GetFileNameWithoutExtension(projectName1))).Value;
+            ProjectInSolution project2 = s.ProjectsByGuid.FirstOrDefault(i => i.Value.ProjectName.Equals(Path.GetFileNameWithoutExtension(projectName2))).Value;
+            ProjectInSolution project3 = s.ProjectsByGuid.FirstOrDefault(i => i.Value.ProjectName.Equals(Path.GetFileNameWithoutExtension(projectName3))).Value;
+            ProjectInSolution folderA = s.ProjectsByGuid.FirstOrDefault(i => i.Value.ProjectName.Equals("FolderA")).Value;
+            ProjectInSolution folderB = s.ProjectsByGuid.FirstOrDefault(i => i.Value.ProjectName.Equals("FolderB")).Value;
+
+            project1.ParentProjectGuid.ShouldBe(folderA.ProjectGuid);
+            project2.ParentProjectGuid.ShouldBe(folderB.ProjectGuid);
+            project3.ParentProjectGuid.ShouldBeNull();
+            folderA.ProjectType.ShouldBe(SolutionProjectType.SolutionFolder);
+            folderB.ProjectType.ShouldBe(SolutionProjectType.SolutionFolder);
         }
 
         private void ValidateProjectInSolution(Action<SlnProject, ProjectInSolution> customValidator, SlnProject[] projects, bool folders)

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
@@ -563,6 +563,7 @@ EndGlobal
             string projectName1 = Path.GetFileName(Path.GetTempFileName());
             string projectName2 = Path.GetFileName(Path.GetTempFileName());
             string projectName3 = Path.GetFileName(Path.GetTempFileName());
+            string projectName4 = Path.GetFileName(Path.GetTempFileName());
             Project[] projects =
             {
                 new Project
@@ -571,16 +572,21 @@ EndGlobal
                 },
                 new Project
                 {
-                    FullPath = Path.Combine(root, "SubFolder1", "Project2", projectName2),
+                    FullPath = Path.Combine(root, "SubFolder2", "Project2", projectName2),
                 },
                 new Project
                 {
-                    FullPath = Path.Combine(root, "SubFolder2", "Project3", projectName3),
+                    FullPath = Path.Combine(root, "SubFolder3", "Project3", projectName3),
+                },
+                new Project
+                {
+                    FullPath = Path.Combine(root, "SubFolder4", "Project4", projectName4),
                 },
             };
 
             projects[0].SetProperty(MSBuildPropertyNames.SlnGenSolutionFolder, "FolderA");
             projects[1].SetProperty(MSBuildPropertyNames.SlnGenSolutionFolder, "FolderB");
+            projects[2].SetProperty(MSBuildPropertyNames.SlnGenSolutionFolder, "FolderB");
 
             string solutionFilePath = GetTempFileName();
 
@@ -594,12 +600,14 @@ EndGlobal
             ProjectInSolution project1 = s.ProjectsByGuid.FirstOrDefault(i => i.Value.ProjectName.Equals(Path.GetFileNameWithoutExtension(projectName1))).Value;
             ProjectInSolution project2 = s.ProjectsByGuid.FirstOrDefault(i => i.Value.ProjectName.Equals(Path.GetFileNameWithoutExtension(projectName2))).Value;
             ProjectInSolution project3 = s.ProjectsByGuid.FirstOrDefault(i => i.Value.ProjectName.Equals(Path.GetFileNameWithoutExtension(projectName3))).Value;
+            ProjectInSolution project4 = s.ProjectsByGuid.FirstOrDefault(i => i.Value.ProjectName.Equals(Path.GetFileNameWithoutExtension(projectName4))).Value;
             ProjectInSolution folderA = s.ProjectsByGuid.FirstOrDefault(i => i.Value.ProjectName.Equals("FolderA")).Value;
             ProjectInSolution folderB = s.ProjectsByGuid.FirstOrDefault(i => i.Value.ProjectName.Equals("FolderB")).Value;
 
             project1.ParentProjectGuid.ShouldBe(folderA.ProjectGuid);
             project2.ParentProjectGuid.ShouldBe(folderB.ProjectGuid);
-            project3.ParentProjectGuid.ShouldBeNull();
+            project3.ParentProjectGuid.ShouldBe(folderB.ProjectGuid);
+            project4.ParentProjectGuid.ShouldBeNull();
             folderA.ProjectType.ShouldBe(SolutionProjectType.SolutionFolder);
             folderB.ProjectType.ShouldBe(SolutionProjectType.SolutionFolder);
         }

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnHierarchyTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnHierarchyTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 },
             };
 
-            SlnHierarchy hierarchy = new SlnHierarchy(projects);
+            SlnHierarchy hierarchy = SlnHierarchy.CreateFromProjectDirectories(projects);
 
             hierarchy.Folders.Select(i => i.FullPath).ShouldBe(new[]
             {
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             List<SlnProject> projects = root.GetAllProjects();
 
-            SlnHierarchy hierarchy = new SlnHierarchy(projects);
+            SlnHierarchy hierarchy = SlnHierarchy.CreateFromProjectDirectories(projects);
 
             hierarchy.Folders.Select(i => i.FullPath).OrderBy(s => s)
                 .ShouldBe(root.GetAllFolders().Select(f => f.FullPath).OrderBy(s => s));
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
             rootExpected.Projects.Add(bar1);
             rootExpected.AddSubDirectory($"foo1 {SlnHierarchy.Separator} foo2 {SlnHierarchy.Separator} baz3").Projects.Add(baz3);
 
-            SlnHierarchy hierarchy = new SlnHierarchy(root.GetAllProjects(), collapseFolders: true);
+            SlnHierarchy hierarchy = SlnHierarchy.CreateFromProjectDirectories(root.GetAllProjects(), collapseFolders: true);
 
             SlnFolder[] resultFolders = hierarchy.Folders.OrderBy(f => f.FullPath).ToArray();
             DummyFolder[] expectedFolders = rootExpected.GetAllFolders().OrderBy(f => f.FullPath).ToArray();

--- a/src/Microsoft.VisualStudio.SlnGen/MSBuildPropertyNames.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/MSBuildPropertyNames.cs
@@ -100,6 +100,11 @@ namespace Microsoft.VisualStudio.SlnGen
         public const string SlnGenSolutionFileFullPath = nameof(SlnGenSolutionFileFullPath);
 
         /// <summary>
+        /// Represents the name of a solution folder to place the project in.
+        /// </summary>
+        public const string SlnGenSolutionFolder = nameof(SlnGenSolutionFolder);
+
+        /// <summary>
         /// Represents the SlnGenUseShellExecute property.
         /// </summary>
         public const string SlnGenUseShellExecute = nameof(SlnGenUseShellExecute);

--- a/src/Microsoft.VisualStudio.SlnGen/SlnHierarchy.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnHierarchy.cs
@@ -87,6 +87,8 @@ namespace Microsoft.VisualStudio.SlnGen
                         Parent = hierarchy._rootFolder,
                     };
 
+                    hierarchy._pathToSlnFolderMap.Add(project.SolutionFolder, folder);
+
                     hierarchy._rootFolder.Folders.Add(folder);
                 }
 

--- a/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
@@ -110,6 +110,11 @@ namespace Microsoft.VisualStudio.SlnGen
         public Guid ProjectTypeGuid { get; set; }
 
         /// <summary>
+        /// Gets or sets the name of a solution folder to place the project in.
+        /// </summary>
+        public string SolutionFolder { get; set; }
+
+        /// <summary>
         /// Creates a solution project from the specified MSBuild project.
         /// </summary>
         /// <param name="project">The <see cref="Project " /> from MSBuild to create a solution project for.</param>
@@ -141,14 +146,15 @@ namespace Microsoft.VisualStudio.SlnGen
 
             return new SlnProject
             {
+                Configurations = GetConfigurations(project, projectFileExtension, isUsingMicrosoftNETSdk),
                 FullPath = project.FullPath,
-                Name = name,
-                ProjectGuid = GetProjectGuid(project, isUsingMicrosoftNETSdk),
-                ProjectTypeGuid = GetProjectTypeGuid(projectFileExtension, isUsingMicrosoftNETSdk, customProjectTypeGuids),
                 IsDeployable = GetIsDeployable(project, projectFileExtension),
                 IsMainProject = isMainProject,
-                Configurations = GetConfigurations(project, projectFileExtension, isUsingMicrosoftNETSdk),
+                Name = name,
                 Platforms = GetPlatforms(project, projectFileExtension, isUsingMicrosoftNETSdk),
+                ProjectGuid = GetProjectGuid(project, isUsingMicrosoftNETSdk),
+                ProjectTypeGuid = GetProjectTypeGuid(projectFileExtension, isUsingMicrosoftNETSdk, customProjectTypeGuids),
+                SolutionFolder = project.GetPropertyValueOrDefault(MSBuildPropertyNames.SlnGenSolutionFolder, string.Empty),
             };
         }
 


### PR DESCRIPTION
Projects cannot specify a value with a directory separator because Visual Studio doesn't support that and the logic isn't powerful enough to parse them.