### PR TITLE
Restore previous project load settings

### DIFF
--- a/src/Shared/ProjectLoading/ProjectGraphProjectLoader.cs
+++ b/src/Shared/ProjectLoading/ProjectGraphProjectLoader.cs
@@ -17,7 +17,10 @@ namespace Microsoft.VisualStudio.SlnGen.ProjectLoading
     /// </summary>
     internal class ProjectGraphProjectLoader : IProjectLoader
     {
-        private static readonly ProjectLoadSettings DefaultProjectLoadSettings = ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition;
+        private static readonly ProjectLoadSettings DefaultProjectLoadSettings = ProjectLoadSettings.IgnoreEmptyImports
+                                                                                 | ProjectLoadSettings.IgnoreInvalidImports
+                                                                                 | ProjectLoadSettings.IgnoreMissingImports
+                                                                                 | ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition;
 
         private readonly ISlnGenLogger _logger;
 


### PR DESCRIPTION
Project load settings used to ignore missing imports which was erroneously removed.