### PR TITLE
Add sqlproj project support

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnProjectTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnProjectTests.cs
@@ -81,6 +81,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         [InlineData(ProjectFileExtensions.VisualBasic)]
         [InlineData(ProjectFileExtensions.FSharp)]
         [InlineData(ProjectFileExtensions.Wix)]
+        [InlineData(ProjectFileExtensions.SqlServerDb)]
         [InlineData(ProjectFileExtensions.AzureServiceFabric)]
         [InlineData(ProjectFileExtensions.Scope)]
         public void GetProjectTypeGuidLegacyProject(string extension)
@@ -113,6 +114,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         [InlineData(ProjectFileExtensions.VisualBasic)]
         [InlineData(ProjectFileExtensions.FSharp)]
         [InlineData(ProjectFileExtensions.Wix)]
+        [InlineData(ProjectFileExtensions.SqlServerDb)]
         public void GetProjectTypeGuidSdkProject(string extension)
         {
             Dictionary<string, string> globalProperties = new Dictionary<string, string>

--- a/src/Shared/ProjectFileExtensions.cs
+++ b/src/Shared/ProjectFileExtensions.cs
@@ -68,5 +68,10 @@ namespace Microsoft.VisualStudio.SlnGen
         /// WiX projects (.wixproj).
         /// </summary>
         public const string Wix = ".wixproj";
+
+        /// <summary>
+        /// SQL Server database projects (.sqlproj).
+        /// </summary>
+        public const string SqlServerDb = ".sqlproj";
     }
 }

--- a/src/Shared/SlnProject.cs
+++ b/src/Shared/SlnProject.cs
@@ -62,6 +62,7 @@ namespace Microsoft.VisualStudio.SlnGen
             [ProjectFileExtensions.NuProj] = new Guid(VisualStudioProjectTypeGuids.NuProj),
             [ProjectFileExtensions.Scope] = new Guid(VisualStudioProjectTypeGuids.ScopeProject),
             [ProjectFileExtensions.Wix] = new Guid(VisualStudioProjectTypeGuids.Wix),
+            [ProjectFileExtensions.SqlServerDb] = new Guid(VisualStudioProjectTypeGuids.SqlServerDbProject),
         };
 
         /// <summary>

--- a/src/Shared/VisualStudioProjectTypeGuids.cs
+++ b/src/Shared/VisualStudioProjectTypeGuids.cs
@@ -73,5 +73,10 @@ namespace Microsoft.VisualStudio.SlnGen
         /// WiX projects (.wixproj).
         /// </summary>
         public const string Wix = "930C7802-8A8C-48F9-8165-68863BCCD9DD";
+
+        /// <summary>
+        /// SQL Server database projects (.sqlproj).
+        /// </summary>
+        public const string SqlServerDbProject = "00D1A9C2-B5F0-4AF3-8072-F6C62B433612";
     }
 }


### PR DESCRIPTION
When generating solutions based on older .sqlproj projects, slngen generates a legacy C# solution type which is missing Visual Studio's SQL features. 

By adding "SlnGenCustomProjectTypeGuid" to each sqlproj, this issue can be worked around. Although, it seems that slngen should support this type of Microsoft project natively. 

This PR is adding the correct project type so that Visual Studio correctly identifies the project. I have made unit test changes and validated they pass. 

Symptoms of project misidentification:
Visual Studio doesn't show SQL features like "Publish" when right-clicking on a sqlproj project in Solution Explorer.