### PR TITLE
Update docs with supported project types

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -148,17 +148,17 @@ Use the following properties and items to customize the generated Solution file.
 SlnGen knows about the following project types:
 * Azure SDK projects (.ccproj)
 * Azure Service Fabric projects (.sfproj)
-* Visual C++ projects (.vcxproj)
 * C# projects (.csproj)
 * F# projects (.fsproj)
-* Visual J# projects (.vjsproj)
 * Legacy C++ projects (.vcproj)
 * Native projects (.nativeProj)
 * NuProj projects (.nuproj)
 * Scope SDK projects (.scopeproj)
-* Visual Basic projects (.vbproj)
-* WiX projects (.wixproj)
 * SQL Server database projects (.sqlproj)
+* Visual Basic projects (.vbproj)
+* Visual C++ projects (.vcxproj)
+* Visual J# projects (.vjsproj)
+* WiX projects (.wixproj)
 
 To add to this list or override an item, specify an `SlnGenCustomProjectTypeGuid` item in your projects.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -146,6 +146,19 @@ Use the following properties and items to customize the generated Solution file.
 
 ## Custom Project Types
 SlnGen knows about the following project types:
+* Azure SDK projects (.ccproj)
+* Azure Service Fabric projects (.sfproj)
+* Visual C++ projects (.vcxproj)
+* C# projects (.csproj)
+* F# projects (.fsproj)
+* Visual J# projects (.vjsproj)
+* Legacy C++ projects (.vcproj)
+* Native projects (.nativeProj)
+* NuProj projects (.nuproj)
+* Scope SDK projects (.scopeproj)
+* Visual Basic projects (.vbproj)
+* WiX projects (.wixproj)
+* SQL Server database projects (.sqlproj)
 
 To add to this list or override an item, specify an `SlnGenCustomProjectTypeGuid` item in your projects.
 


### PR DESCRIPTION
The current README is missing the list of supported project types.

Is this supposed to be dynamic?
I noticed the list was empty at: https://microsoft.github.io/slngen/

I found the current list from slngen/src/Shared/ProjectFileExtensions.cs 
This PR is adding that list in a bullet list to the README.md file.