### PR TITLE
Add support for file system globbing of project paths.

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -18,6 +18,7 @@
     <PackageReference Update="Shouldly" Version="4.0.3" />
     <PackageReference Update="xunit" Version="2.4.1" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">

--- a/Packages.props
+++ b/Packages.props
@@ -9,6 +9,7 @@
     <PackageReference Update="Microsoft.Build" Version="16.8.0" />
     <PackageReference Update="Microsoft.Build.Runtime" Version="16.8.0" />
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="16.8.0" />
+    <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="2.3.2262-g94fae01e" />
     <PackageReference Update="Microsoft.VisualStudio.Telemetry" Version="16.3.59" />
@@ -18,7 +19,6 @@
     <PackageReference Update="Shouldly" Version="4.0.3" />
     <PackageReference Update="xunit" Version="2.4.1" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">

--- a/src/Microsoft.VisualStudio.SlnGen.Tool/Microsoft.VisualStudio.SlnGen.Tool.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen.Tool/Microsoft.VisualStudio.SlnGen.Tool.csproj
@@ -13,4 +13,7 @@
   <ItemGroup>
     <FilesToSign Include="$(IntermediateOutputPath)$(TargetName)$(TargetExt)" Authenticode="Microsoft400" StrongName="StrongName" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/ArgumentsTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/ArgumentsTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         public void ExpandWildcards()
         {
             var root = Path.GetTempPath();
-            var work = Directory.CreateDirectory(Path.Combine(root, "work" + Environment.ProcessId.ToString()));
+            var work = Directory.CreateDirectory(Path.Combine(root, Environment.ProcessId.ToString()));
 
             try
             {
@@ -90,8 +90,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 var result = ProgramArguments.ExpandWildcards(new[] { "**\\*.csproj" });
                 Environment.CurrentDirectory = old;
 
-                var files = result.Select(x => Path.GetFileName(x)).ToArray();
-                Array.Sort(files);
+                var files = result.Select(x => Path.GetFileName(x)).OrderBy<string, string>(x => x).ToArray();
 
                 Assert.Equal(6, files.Length);
                 for (int i = 0; i < files.Length; i++)

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/ExtensionMethodsTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/ExtensionMethodsTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 {
     public class ExtensionMethodsTests
     {
+#if NETFRAMEWORK
         [Fact]
         public void ToFullPathInCorrectCaseDirectory()
         {
@@ -50,6 +51,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 directory.Delete(recursive: true);
             }
         }
+#endif
 
         [Theory]
         [InlineData(@"C:\RootFolder\SubFolder\MoreSubFolder\LastFolder\SomeFile.txt", @"C:\RootFolder\SubFolder\Sibling\Child\", @"..\..\MoreSubFolder\LastFolder\SomeFile.txt")]

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/MSBuildProjectLoaderTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/MSBuildProjectLoaderTests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 {
     public class MSBuildProjectLoaderTests : TestBase
     {
+#if NETFRAMEWORK
         [Fact]
         public void ArgumentNullException_Logger()
         {
@@ -157,5 +158,6 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 new[] { dirsProj.FullPath, projectA.FullPath, projectB.FullPath },
                 ignoreOrder: true);
         }
+#endif
     }
 }

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/Microsoft.VisualStudio.SlnGen.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/Microsoft.VisualStudio.SlnGen.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);SA1600</NoWarn>
   </PropertyGroup>
@@ -14,8 +14,11 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <ProjectReference Include="..\Microsoft.VisualStudio.SlnGen\Microsoft.VisualStudio.SlnGen.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <ProjectReference Include="..\Microsoft.VisualStudio.SlnGen.Tool\Microsoft.VisualStudio.SlnGen.Tool.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\Microsoft.VisualStudio.SlnGen\*.targets" Link="build\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />

--- a/src/Shared/ProgramArguments.Shared.cs
+++ b/src/Shared/ProgramArguments.Shared.cs
@@ -392,7 +392,7 @@ Examples:
             return result.Count > 0;
         }
 
-        private static IEnumerable<string> ExpandWildcards(IEnumerable<string> paths)
+        internal static IEnumerable<string> ExpandWildcards(IEnumerable<string> paths)
         {
 #if NETFRAMEWORK
             return paths;

--- a/src/Shared/ProgramArguments.Shared.cs
+++ b/src/Shared/ProgramArguments.Shared.cs
@@ -3,12 +3,15 @@
 // Licensed under the MIT license.
 
 using McMaster.Extensions.CommandLineUtils;
-using Microsoft.Extensions.FileSystemGlobbing;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+
+#if !NETFRAMEWORK
+using Microsoft.Extensions.FileSystemGlobbing;
+#endif
 
 namespace Microsoft.VisualStudio.SlnGen
 {
@@ -391,6 +394,9 @@ Examples:
 
         private static IEnumerable<string> ExpandWildcards(IEnumerable<string> paths)
         {
+#if NETFRAMEWORK
+            return paths;
+#else
             var results = new List<string>();
             var wild = new List<string>();
 
@@ -414,6 +420,7 @@ Examples:
             }
 
             return results;
+#endif
         }
 
         private bool GetBoolean(string[] values, bool defaultValue = false)

--- a/src/Shared/Shared.props
+++ b/src/Shared/Shared.props
@@ -21,7 +21,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities.Internal" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Shared\**\*.cs" />

--- a/src/Shared/Shared.props
+++ b/src/Shared/Shared.props
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities.Internal" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Shared\**\*.cs" />


### PR DESCRIPTION
With this change, you can now do:

slngen **\*.csproj

And get a solution for all the projects in a directory hierarchy. If
you expand the command-line to:

slngen --folders true --collapsefolders true --ignoreMainProject **\*.csproj

You get a pretty nice-looking solution file that is close to a hand-crafted
one.