### PR TITLE
Target .NET Framework v4.6.1 so that globbing library can be used

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -21,7 +21,7 @@
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Update="Microsoft.Build" Version="15.9.20" />
     <PackageReference Update="Microsoft.Build.Runtime" Version="15.9.20" />
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="15.9.20" />

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -115,7 +115,7 @@ This will generate an `slngen.binlog` that can be opened with the [MSBuild Struc
 
 With the binary log, ensure that the projects aren't missing any imports and they declare `<ProjectReference />` items.
 
-## How does I get support for SlnGen?
+## How do I get support for SlnGen?
 Please search for existing issues to [see if someone has already reported the issue](https://github.com/microsoft/slngen/issues) and if there is a workaround or solution.  If not, please open a [new issue](https://github.com/microsoft/slngen/issues/new) to be investigated.
 
 If possible, include a binary log.  If not, please include the following:

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ slngen [switches] [project]
 
 | Argument | Description |
 |----------|-------------|
-| <code>project</code> | An optional path to a project to generate a solution file for.  If you don't specify a project file, SlnGen searches the current working directory for a file name extension that ends in proj and uses that file. |
+| <code>project</code> | An optional path to a project to generate a solution file for which can include wildcards like **\*.csproj.  If you don't specify a project file, SlnGen searches the current working directory for a file name extension that ends in proj and uses that file. |
 
 ### Switches
 

--- a/src/Microsoft.VisualStudio.SlnGen.Tool/Microsoft.VisualStudio.SlnGen.Tool.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen.Tool/Microsoft.VisualStudio.SlnGen.Tool.csproj
@@ -13,7 +13,4 @@
   <ItemGroup>
     <FilesToSign Include="$(IntermediateOutputPath)$(TargetName)$(TargetExt)" Authenticode="Microsoft400" StrongName="StrongName" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
-  </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net46;net472</TargetFrameworks>
+    <TargetFrameworks>net461;net472</TargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.config</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludeReferenceCopyLocalPathsInBuildOutputInPackage>true</IncludeReferenceCopyLocalPathsInBuildOutputInPackage>
     <IsTool>true</IsTool>
@@ -15,7 +15,8 @@
     </PackageReference>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\$(TargetFramework)\MSBuild.exe" Private="false" />
+    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net46\MSBuild.exe" Private="false" Condition="'$(TargetFramework)' == 'net461'" />
+    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net472\MSBuild.exe" Private="false" Condition="'$(TargetFramework)' == 'net472'" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/src/Microsoft.VisualStudio.SlnGen/Program.NETFramework.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.NETFramework.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.SlnGen
                 remoteLoggers: null,
                 toolsetDefinitionLocations: ToolsetDefinitionLocations.Default,
                 maxNodeCount: 1,
-#if NET46
+#if NET461
                 onlyLogCriticalEvents: false);
 #else
                 onlyLogCriticalEvents: false,

--- a/src/Shared/ProgramArguments.Shared.cs
+++ b/src/Shared/ProgramArguments.Shared.cs
@@ -205,7 +205,7 @@ Examples:
         [Argument(
             0,
             Name = "project path",
-            Description = "An optional path to a project.  If not specified, all projects in the current directory will be used.")]
+            Description = "An optional path to a project which can include wildcards like **\\*.csproj.  If not specified, all projects in the current directory will be used.")]
         public string[] Projects { get; set; }
 
         /// <summary>

--- a/src/Shared/ProjectLoading/ProjectGraphProjectLoader.cs
+++ b/src/Shared/ProjectLoading/ProjectGraphProjectLoader.cs
@@ -2,7 +2,7 @@
 //
 // Licensed under the MIT license.
 
-#if !NET46
+#if !NET461
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;

--- a/src/Shared/ProjectLoading/ProjectLoader.cs
+++ b/src/Shared/ProjectLoading/ProjectLoader.cs
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.SlnGen.ProjectLoading
             return new LegacyProjectLoader(logger);
 #endif
 
-#if NET46
+#if NET461
             return new LegacyProjectLoader(logger);
 #endif
         }

--- a/src/Shared/Shared.props
+++ b/src/Shared/Shared.props
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Build" ExcludeAssets="Runtime" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.Build.Runtime" IncludeAssets="None" PrivateAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities.Internal" />

--- a/src/SlnGen.Corext/SlnGen.Corext.csproj
+++ b/src/SlnGen.Corext/SlnGen.Corext.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets/1.0.94">
   <PropertyGroup>
-    <TargetFrameworks>net46;net472</TargetFrameworks>
+    <TargetFrameworks>net461;net472</TargetFrameworks>
     <ArtifactsPath>$(BaseArtifactsPath)\$(MSBuildProjectName)</ArtifactsPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>CoreXT Solution Generator</Title>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "5.0",
+  "version": "5.1",
   "assemblyVersion": "3.0",
   "buildNumberOffset": -1,
   "publicReleaseRefSpec": [


### PR DESCRIPTION
Follow up to https://github.com/microsoft/slngen/pull/205

Change target framework to net461 and use globbing library in .NET Framework.

Also changed to version 5.1 in case this is a breaking change