### PR TITLE
Allow project Configuration to map to first solution Configuration

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             ValidateSolutionPlatformAndConfiguration(projectD, solutionFile, "Debug", "Razzle", expectedIncludeInBuild: false);
 
-            ValidateSolutionPlatformAndConfiguration(projectE, solutionFile, "Release", "AnyCPU", expectedIncludeInBuild: false);
+            ValidateSolutionPlatformAndConfiguration(projectE, solutionFile, "Release", "AnyCPU", expectedIncludeInBuild: true);
         }
 
         [Fact]

--- a/src/Shared/SlnFile.cs
+++ b/src/Shared/SlnFile.cs
@@ -516,7 +516,7 @@ namespace Microsoft.VisualStudio.SlnGen
 
             projectSolutionConfiguration = project.Configurations.First();
 
-            return false;
+            return true;
         }
 
         private bool TryGetProjectSolutionPlatform(string solutionPlatform, SlnProject project, out string projectSolutionPlatform, out string projectBuildPlatform)


### PR DESCRIPTION
This allows a project to be included in the build even if a matching configuration could not be found.  This aligns with Visual Studio behavior when you manually add a project.