### PR TITLE
Fix collapsed folder generation

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnHierarchyTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnHierarchyTests.cs
@@ -72,6 +72,31 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         }
 
         [Fact]
+        public void HierarchyWithMultipleSubfoldersUnderACollapsedFolderIsCorrectlyFormed()
+        {
+            DummyFolder root = DummyFolder.CreateRoot(@"D:\foo\");
+            DummyFolder src = root.AddSubDirectory("src");
+            DummyFolder subfolder = src.AddSubDirectory("subfolder");
+            DummyFolder subfolderSrc = subfolder.AddSubDirectory("src");
+            DummyFolder subfolderTests = subfolder.AddSubDirectory("tests");
+            SlnProject project1 = subfolderSrc.AddProjectWithDirectory("project1");
+            SlnProject project1tests = subfolderTests.AddProjectWithDirectory("project1tests");
+            SlnProject project2 = root.AddProjectWithDirectory("project2");
+
+            DummyFolder rootExpected = DummyFolder.CreateRoot(@"D:\foo");
+            DummyFolder subfolderExpected = rootExpected.AddSubDirectory($"src {SlnHierarchy.Separator} subfolder");
+            DummyFolder project1Expected = subfolderExpected.AddSubDirectory($"src {SlnHierarchy.Separator} project1");
+            project1Expected.Projects.Add(project1);
+            DummyFolder project1testsExpected = subfolderExpected.AddSubDirectory($"tests {SlnHierarchy.Separator} project1tests");
+            project1testsExpected.Projects.Add(project1tests);
+            rootExpected.Projects.Add(project2);
+
+            SlnHierarchy hierarchy = SlnHierarchy.CreateFromProjectDirectories(root.GetAllProjects(), collapseFolders: true);
+
+            CompareFolders(rootExpected.GetAllFolders(), hierarchy.Folders);
+        }
+
+        [Fact]
         public void HierarchyWithCollapsedFoldersIsCorrectlyFormed()
         {
             DummyFolder root = DummyFolder.CreateRoot(@"D:\zoo\foo");
@@ -96,8 +121,13 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             SlnHierarchy hierarchy = SlnHierarchy.CreateFromProjectDirectories(root.GetAllProjects(), collapseFolders: true);
 
-            SlnFolder[] resultFolders = hierarchy.Folders.OrderBy(f => f.FullPath).ToArray();
-            DummyFolder[] expectedFolders = rootExpected.GetAllFolders().OrderBy(f => f.FullPath).ToArray();
+            CompareFolders(rootExpected.GetAllFolders(), hierarchy.Folders);
+        }
+
+        private static void CompareFolders(IEnumerable<DummyFolder> expected, IEnumerable<SlnFolder> result)
+        {
+            SlnFolder[] resultFolders = result.OrderBy(f => f.FullPath).ToArray();
+            DummyFolder[] expectedFolders = expected.OrderBy(f => f.FullPath).ToArray();
 
             resultFolders.Length.ShouldBe(expectedFolders.Length);
 
@@ -115,20 +145,25 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 // Verify that expected and results child folders match
                 resultFolder.Folders.Count.ShouldBe(expectedFolder.Folders.Count);
                 resultFolder.Folders.ShouldAllBe(p => expectedFolder.Folders.Exists(f => f.Name == p.Name));
+
+                // Verify that the parent folders match
+                resultFolder.Parent?.FullPath.ShouldBe(expectedFolder.Parent?.FullPath);
             }
         }
 
         private class DummyFolder
         {
-            private DummyFolder(string path)
+            private DummyFolder(string path, DummyFolder parent)
             {
                 FileInfo fileInfo = new FileInfo(path);
 
                 Folders = new List<DummyFolder>();
                 Projects = new List<SlnProject>();
 
-                FullPath = path;
+                FullPath = fileInfo.FullName.Split(new[] { $" {SlnHierarchy.Separator} " }, StringSplitOptions.None)[0];
                 Name = fileInfo.Name;
+
+                Parent = parent;
             }
 
             public List<DummyFolder> Folders { get; }
@@ -139,9 +174,11 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             public List<SlnProject> Projects { get; }
 
+            public DummyFolder Parent { get; }
+
             public static DummyFolder CreateRoot(string rootPath)
             {
-                return new DummyFolder(rootPath);
+                return new DummyFolder(rootPath, null);
             }
 
             public SlnProject AddProjectWithDirectory(string name)
@@ -153,7 +190,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
             {
                 string path = Path.Combine(FullPath, folderName);
 
-                DummyFolder childFolder = new DummyFolder(path);
+                DummyFolder childFolder = new DummyFolder(path, this);
 
                 Folders.Add(childFolder);
 

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnHierarchyTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnHierarchyTests.cs
@@ -72,6 +72,30 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         }
 
         [Fact]
+        public void SingleFolderWithProjectsShouldNotCollapseIntoParentFolderWithProjects()
+        {
+            DummyFolder root = DummyFolder.CreateRoot(@"D:\foo\");
+            DummyFolder src = root.AddSubDirectory("src");
+            DummyFolder subfolder = src.AddSubDirectory("subfolder");
+            SlnProject project1 = subfolder.AddProjectWithDirectory("project1");
+            SlnProject project1Tests = subfolder.AddProjectWithDirectory("project1Tests");
+            SlnProject project2 = src.AddProjectWithDirectory("project2");
+            SlnProject project3 = root.AddProjectWithDirectory("project3");
+
+            DummyFolder rootExpected = DummyFolder.CreateRoot(@"D:\foo");
+            DummyFolder srcExpected = rootExpected.AddSubDirectory("src");
+            DummyFolder subfolderExpected = srcExpected.AddSubDirectory("subfolder");
+            subfolderExpected.Projects.Add(project1);
+            subfolderExpected.Projects.Add(project1Tests);
+            srcExpected.Projects.Add(project2);
+            rootExpected.Projects.Add(project3);
+
+            SlnHierarchy hierarchy = SlnHierarchy.CreateFromProjectDirectories(root.GetAllProjects(), collapseFolders: true);
+
+            CompareFolders(rootExpected.GetAllFolders(), hierarchy.Folders);
+        }
+
+        [Fact]
         public void HierarchyWithMultipleSubfoldersUnderACollapsedFolderIsCorrectlyFormed()
         {
             DummyFolder root = DummyFolder.CreateRoot(@"D:\foo\");
@@ -80,15 +104,15 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
             DummyFolder subfolderSrc = subfolder.AddSubDirectory("src");
             DummyFolder subfolderTests = subfolder.AddSubDirectory("tests");
             SlnProject project1 = subfolderSrc.AddProjectWithDirectory("project1");
-            SlnProject project1tests = subfolderTests.AddProjectWithDirectory("project1tests");
+            SlnProject project1Tests = subfolderTests.AddProjectWithDirectory("project1Tests");
             SlnProject project2 = root.AddProjectWithDirectory("project2");
 
             DummyFolder rootExpected = DummyFolder.CreateRoot(@"D:\foo");
             DummyFolder subfolderExpected = rootExpected.AddSubDirectory($"src {SlnHierarchy.Separator} subfolder");
-            DummyFolder project1Expected = subfolderExpected.AddSubDirectory($"src {SlnHierarchy.Separator} project1");
-            project1Expected.Projects.Add(project1);
-            DummyFolder project1testsExpected = subfolderExpected.AddSubDirectory($"tests {SlnHierarchy.Separator} project1tests");
-            project1testsExpected.Projects.Add(project1tests);
+            DummyFolder subfolderSrcExpected = subfolderExpected.AddSubDirectory("src");
+            subfolderSrcExpected.Projects.Add(project1);
+            DummyFolder subfolderTestsExpected = subfolderExpected.AddSubDirectory("tests");
+            subfolderTestsExpected.Projects.Add(project1Tests);
             rootExpected.Projects.Add(project2);
 
             SlnHierarchy hierarchy = SlnHierarchy.CreateFromProjectDirectories(root.GetAllProjects(), collapseFolders: true);
@@ -117,7 +141,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
             barQuxExpected.Projects.Add(baz1);
             barQuxExpected.Projects.Add(baz2);
             rootExpected.Projects.Add(bar1);
-            rootExpected.AddSubDirectory($"foo1 {SlnHierarchy.Separator} foo2 {SlnHierarchy.Separator} baz3").Projects.Add(baz3);
+            rootExpected.AddSubDirectory($"foo1 {SlnHierarchy.Separator} foo2").Projects.Add(baz3);
 
             SlnHierarchy hierarchy = SlnHierarchy.CreateFromProjectDirectories(root.GetAllProjects(), collapseFolders: true);
 

--- a/src/Shared/SlnHierarchy.cs
+++ b/src/Shared/SlnHierarchy.cs
@@ -113,6 +113,7 @@ namespace Microsoft.VisualStudio.SlnGen
                 folderWithSingleChild.Projects.AddRange(child.Projects);
                 folderWithSingleChild.Folders.Clear();
                 folderWithSingleChild.Folders.AddRange(child.Folders);
+                folderWithSingleChild.Folders.ForEach(f => f.Parent = folderWithSingleChild);
             }
         }
 

--- a/src/Shared/SlnHierarchy.cs
+++ b/src/Shared/SlnHierarchy.cs
@@ -62,8 +62,8 @@ namespace Microsoft.VisualStudio.SlnGen
 
             if (collapseFolders)
             {
-                CollapseFolders(rootFolder.Folders);
                 RemoveLeaves(rootFolder);
+                CollapseFolders(rootFolder.Folders);
             }
 
             return hierarchy;
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.SlnGen
                 CollapseFolders(folder.Folders);
             }
 
-            foreach (SlnFolder folderWithSingleChild in folders.Where(i => i.Folders.Count == 1))
+            foreach (SlnFolder folderWithSingleChild in folders.Where(i => i.Folders.Count == 1 && i.Projects.Count == 0))
             {
                 SlnFolder child = folderWithSingleChild.Folders.First();
 
@@ -211,9 +211,8 @@ namespace Microsoft.VisualStudio.SlnGen
             if (folder.Folders.Count == 0)
             {
                 // We want to remove leaves that have only a single project. There is no need to keep that
-                // directory as it would be represented by the project file itself. We ignore folders that
-                // contain the Separator character as these are folders which have been collapsed already.
-                return folder.Projects.Count == 1 && !folder.Name.Contains(Separator);
+                // directory as it would be represented by the project file itself.
+                return folder.Projects.Count == 1;
             }
 
             List<SlnFolder> foldersToRemove = new List<SlnFolder>();


### PR DESCRIPTION
When generating a solution based on a folder tree, the `slngen` can create a broken .sln file, in which some projects are not connected to any parent. Also, sometimes a project folder can be collapsed into its parent folder instead of being replaced by the project itself.

Here is an example of such project tree: [slngenTestProject.zip](https://github.com/microsoft/slngen/files/6682366/slngenTestProject.zip)
The folder structure looks like this: 
![slngenTestProject](https://user-images.githubusercontent.com/37192399/122675253-6fba3400-d18d-11eb-95b1-5edbb4d116f4.jpg)

To test it, execute the `slngen` with parameters `--solutionfile "<pathToSlngenTestProject>\slngenTestProject.sln" --folders true --collapsefolders true --nologo --launch false "<pathToSlngenTestProject>\dirs.proj"`.
The changed code is executed only when both parameters `--folders true` and `--collapsefolders true` are used.

Version 5.3.0 generates the following solution: 
![slngenCurrent](https://user-images.githubusercontent.com/37192399/122675301-a55f1d00-d18d-11eb-8060-96a498d473d9.jpg)

After this PR, the generated solution looks like this: 
![slngenAfterPr](https://user-images.githubusercontent.com/37192399/122675324-bdcf3780-d18d-11eb-9e93-2a4e1a9c2f82.jpg)

I did not investigate, why there is a root folder `slngenTestProject` (https://github.com/microsoft/slngen/issues/196), nor why the `project3` is outside of it. But that's not a regression caused by this PR.

I also tested this with a few of my more complex project trees and I didn't notice any regressions. However, there aren't many unit tests covering the feature.