### PR TITLE
Remove unneeded PackageReferences

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -16,16 +16,6 @@
     <PackageReference Update="Microsoft.VisualStudio.Utilities.Internal" Version="16.3.23" />
     <PackageReference Update="MSBuild.ProjectCreation" Version="4.0.4" />
     <PackageReference Update="Shouldly" Version="4.0.3" />
-    <PackageReference Update="System.Collections" Version="4.3.0" />
-    <PackageReference Update="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Update="System.Diagnostics.Debug" Version="4.3.0" />
-    <PackageReference Update="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Update="System.Resources.ResourceManager" Version="4.3.0" />
-    <PackageReference Update="System.Runtime.Extensions" Version="4.3.0" />
-    <PackageReference Update="System.Runtime.Handles" Version="4.3.0" />
-    <PackageReference Update="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Update="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageReference Update="System.Threading" Version="4.3.0" />
     <PackageReference Update="xunit" Version="2.4.1" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/Packages.props
+++ b/Packages.props
@@ -15,6 +15,7 @@
     <PackageReference Update="Microsoft.VisualStudio.Telemetry" Version="16.3.176" />
     <PackageReference Update="Microsoft.VisualStudio.Utilities.Internal" Version="16.3.23" />
     <PackageReference Update="MSBuild.ProjectCreation" Version="4.0.4" />
+    <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Update="Shouldly" Version="4.0.3" />
     <PackageReference Update="xunit" Version="2.4.1" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.3" />

--- a/Packages.props
+++ b/Packages.props
@@ -34,7 +34,6 @@
 
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="2.2.0" />
-    <GlobalPackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <GlobalPackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.4.228" />

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities.Internal" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net46\MSBuild.exe" Private="false" Condition="'$(TargetFramework)' == 'net461'" />

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
@@ -27,17 +27,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Utilities.Internal" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Collections" />
-    <PackageReference Include="System.Diagnostics.Debug" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" />
-    <PackageReference Include="System.Resources.ResourceManager" />
-    <PackageReference Include="System.Runtime.Extensions" />
-    <PackageReference Include="System.Runtime.Handles" />
-    <PackageReference Include="System.Runtime.InteropServices" />
-    <PackageReference Include="System.Text.Encoding.Extensions" />
-    <PackageReference Include="System.Threading" />
-  </ItemGroup>
   <ItemGroup>
     <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net46\MSBuild.exe" Private="false" Condition="'$(TargetFramework)' == 'net461'" />
     <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net472\MSBuild.exe" Private="false" Condition="'$(TargetFramework)' == 'net472'" />

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
@@ -25,6 +25,8 @@
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities.Internal" />
+    <!-- Transitive dependency of M.VS.Telemetry but referencing directly to upgrade the used version to not depend on old runtime packages. -->
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net46\MSBuild.exe" Private="false" Condition="'$(TargetFramework)' == 'net461'" />


### PR DESCRIPTION
cc @jeffkl

The removed package references are already part of the Microsoft.NETCore.App.Ref targeting pack and don't need to be brought into the closure via PackageReferences.

The Microsoft.NETFramework.ReferenceAssemblies package reference is implicitly defined by the SDK for some years now and hence doesn't need to be specified explicitly anymore.