### PR TITLE
Be more strict about locating MSBuild.exe

### DIFF
--- a/src/Shared/Utility.cs
+++ b/src/Shared/Utility.cs
@@ -19,30 +19,22 @@ namespace Microsoft.VisualStudio.SlnGen
         /// </summary>
         public static readonly bool RunningOnWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
-        private static readonly Lazy<string[]> PathExtLazy = new (() =>
-        {
-            string pathExt = Environment.GetEnvironmentVariable("PATHEXT");
-
-            return string.IsNullOrWhiteSpace(pathExt)
-                ? new[] { string.Empty }
-                : pathExt.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).ToArray();
-        });
-
         /// <summary>
         /// Attempts to find the specified executable on the PATH.
         /// </summary>
         /// <param name="exe">The name of the executable to find.</param>
+        /// <param name="validator">A <see cref="Func{T, TResult}" /> that validates if a found item on the PATH is what the caller is looking for.</param>
         /// <param name="fileInfo">Receives a <see cref="FileInfo" /> object with details about the executable if found.</param>
         /// <returns><code>true</code> if an executable could be found, otherwise <code>false</code>.</returns>
-        public static bool TryFindOnPath(string exe, out FileInfo fileInfo)
+        public static bool TryFindOnPath(string exe, Func<FileInfo, bool> validator, out FileInfo fileInfo)
         {
             fileInfo = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
                 .Split(Path.PathSeparator)
                 .Where(i => !string.IsNullOrWhiteSpace(i))
                 .Select(i => new DirectoryInfo(i.Trim()))
                 .Where(i => i.Exists)
-                .SelectMany(i => PathExtLazy.Value.Select(extension => new FileInfo(Path.Combine(i.FullName, $"{exe}{extension}").ToFullPathInCorrectCase())))
-                .FirstOrDefault(i => i.Exists);
+                .Select(i => new FileInfo(Path.Combine(i.FullName, $"{exe}").ToFullPathInCorrectCase()))
+                .FirstOrDefault(i => i.Exists && (validator == null || validator(i)));
 
             return fileInfo != null;
         }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.2",
+  "version": "6.3",
   "assemblyVersion": "3.0",
   "buildNumberOffset": -1,
   "publicReleaseRefSpec": [


### PR DESCRIPTION
If a user has an msbuild.bat on the PATH or some really old version, SlnGen won't work and there is no alternative action a user can do to get unblocked.

This change makes the search for MSBuild.exe more strict by only looking for MSBuild.exe and requiring that it be version 15 or above.

Fixes #278