### PR TITLE
Do not normalize paths from mapped network drives

### DIFF
--- a/src/Shared/ExtensionMethods.Shared.cs
+++ b/src/Shared/ExtensionMethods.Shared.cs
@@ -43,7 +43,12 @@ namespace Microsoft.VisualStudio.SlnGen
 
                 GetFinalPathNameByHandle(stream.SafeFileHandle, stringBuilder, stringBuilder.Capacity, 0);
 
-                return stringBuilder.ToString(4, stringBuilder.Capacity - 5);
+                // The path must begin with \\?\X:in order to be made into a path that Visual Studio can use.
+                // Mapped network drives return a value like "// \\?\UNC\MachineName\C$" which won't work so the original path must be used
+                if (stringBuilder.Length > 7 && stringBuilder[0] == '\\' && stringBuilder[1] == '\\' && stringBuilder[2] == '?' && stringBuilder[3] == '\\' && stringBuilder[5] == ':' && stringBuilder[6] == '\\')
+                {
+                    return stringBuilder.ToString(4, stringBuilder.Capacity - 5);
+                }
             }
 
             return path;


### PR DESCRIPTION
On Windows, the `GetFinalPathNameByHandle` function returns the UNC path if the specified path is from a mapped network drive.  These paths break Visual Studio so they can't be used.  This change detects if the path was normalized and isn't from a network drive, otherwise the original path is used.

Fixes #305