### PR TITLE
Stop using shell execute

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,8 +71,6 @@ Options:
   --ignoreMainProject                 None of the projects receive special treatment.
   --launch <true|false>               Launch Visual Studio after generating the Solution file. Default: true on Windows
   --loadprojects <false>              When launching Visual Studio, opens the specified solution without loading any projects. Default: true
-                                      You must disable shell execute when using this command-line option.
-                                        --useshellexecute:false
   --logger                            Use this logger to log events from SlnGen. To specify multiple loggers, specify each logger separately.
                                       The <logger> syntax is:
                                         [<class>,]<assembly>[;<parameters>]
@@ -90,7 +88,6 @@ Options:
   -p|--property <name=value[;]>       Set or override these project-level properties. <name> is the property name, and <value> is the property value. Use a semicolon or a comma to separate multiple properties, or specify each property separately.
                                         Example:
                                           --property:WarningLevel=2;MyProperty=true
-  -u|--useshellexecute <false>        Indicates whether or not the Visual Studio solution file should be opened by the registered file extension handler. Default: true
   -d|--solutiondir <path>             An optional path to the directory in which the solution file will be generated. Defaults to the same directory as the project. --solutionfile will take precedence over this switch.
   -o|--solutionfile <path>            An optional path to the solution file to generate. Defaults to the same directory as the project.
   -v|--verbosity                      Display this amount of information in the event log. The available verbosity levels are:
@@ -125,7 +122,6 @@ The following properties only apply when using SlnGen as an MSBuild target.
 |--------------------------|------------------------------------------------------------------------------------------------------------|--------------------|---------|
 | `SlnGenLaunchVisualStudio` | Indicates whether or not Visual Studio should be launched to open the solution file after it is generated. | `true` or `false` | `true` |
 | `SlnGenSolutionFileFullPath` | Specifies the full path to the Visual Studio solution file to generate.  By default, the path is the same as the project. | | ProjectPath.sln|
-| `SlnGenUseShellExecute` | Indicates whether or not the Visual Studio solution file should be opened by the registered file extension handler.  You can disable this setting to use whatever `devenv.exe` is on your `PATH` or you can specify a full path to `devenve.exe` with the `SlnGenDevEnvFullPath` property. | `true` or `false` | `true` |
 | `SlnGenDevEnvFullPath` | Specifies a full path to Visual Studio's `devenv.exe` to use when opening the solution file.  By default, SlnGen will launch the program associated with the `.sln` file extension.  However, in some cases you may want to specify a custom path to Visual Studio. | | |
 | `SlnGenGlobalProperties` | Specifies MSBuild properties to set when loading projects and project references. | | `DesignTimeBuild=true;BuildingProject=false` |
 | `SlnGenInheritGlobalProperties` | Indicates whether or not all global variables specified when loading the initial project should be passed around when loading project references. | `true` or `false` | `true` |
@@ -136,7 +132,6 @@ The following properties only apply when using SlnGen as an MSBuild target.
 Command-line argument
 ```cmd
 MSBuild.exe /Target:SlnGen /Property:"SlnGenLaunchVisualStudio=false"
-                           /Property:"SlnGenUseShellExecute=false"
                            /Property:"SlnGenDevEnvFullPath=%VSINSTALLDIR%Common7\IDE\devenv.exe"
 ```
 
@@ -145,7 +140,6 @@ MSBuild properties
 <PropertyGroup>
   <SlnGenLaunchVisualStudio>false</SlnGenLaunchVisualStudio>
   <SlnGenSolutionFileFullPath>$(MSBuildProjectDirectory)\$(MSBuildProjectName).sln</SlnGenSolutionFileFullPath>
-  <SlnGenUseShellExecute>false</SlnGenUseShellExecute>
   <SlnGenGlobalProperties>DoNotDoSomethingWhenLoadingProjects=true;TodayIsYesterday=false</SlnGenGlobalProperties>
   <SlnGenInheritGlobalProperties>false</SlnGenInheritGlobalProperties>
   <SlnGenGlobalPropertiesToRemove>Property1;Property2</SlnGenGlobalPropertiesToRemove>

--- a/src/Microsoft.VisualStudio.SlnGen/MSBuildPropertyNames.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/MSBuildPropertyNames.cs
@@ -110,11 +110,6 @@ namespace Microsoft.VisualStudio.SlnGen
         public const string SlnGenSolutionFolder = nameof(SlnGenSolutionFolder);
 
         /// <summary>
-        /// Represents the SlnGenUseShellExecute property.
-        /// </summary>
-        public const string SlnGenUseShellExecute = nameof(SlnGenUseShellExecute);
-
-        /// <summary>
         /// Represents the UsingMicrosoftNETSdk property.
         /// </summary>
         public const string UsingMicrosoftNETSdk = nameof(UsingMicrosoftNETSdk);

--- a/src/Microsoft.VisualStudio.SlnGen/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.cs
@@ -369,7 +369,6 @@ namespace Microsoft.VisualStudio.SlnGen
 #endif
                             ["UseBinaryLogger"] = arguments.BinaryLogger.HasValue.ToString(),
                             ["UseFileLogger"] = arguments.FileLoggerParameters.HasValue.ToString(),
-                            ["UseShellExecute"] = arguments.EnableShellExecute().ToString(),
                             ["CustomProjectTypeGuidCount"] = customProjectTypeGuidCount,
                             ["ProjectCount"] = evaluationCount,
                             ["ProjectEvaluationMilliseconds"] = evaluationTime.TotalMilliseconds,

--- a/src/Microsoft.VisualStudio.SlnGen/ProgramArguments.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ProgramArguments.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.VisualStudio.SlnGen
 {
@@ -147,9 +146,7 @@ Some additional available parameters are:
             "--loadprojects",
             CommandOptionType.MultipleValue,
             ValueName = "false",
-            Description = @"When launching Visual Studio, opens the specified solution without loading any projects.  Default: true
-You must disable shell execute when using this command-line option.
-  --useshellexecute:false")]
+            Description = @"When launching Visual Studio, opens the specified solution without loading any projects.  Default: true")]
         public string[] LoadProjectsInVisualStudio { get; set; }
 
         /// <summary>
@@ -221,16 +218,6 @@ Examples:
         public string[] Property { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the shell should be used when starting the process.
-        /// </summary>
-        [Option(
-            "-u|--useshellexecute",
-            CommandOptionType.MultipleValue,
-            ValueName = "false",
-            Description = "Indicates whether or not the Visual Studio solution file should be opened by the registered file extension handler.  Default: true")]
-        public string[] ShellExecute { get; set; }
-
-        /// <summary>
         /// Gets or sets the full path to the solution file to generate.
         /// </summary>
         [Option(
@@ -283,12 +270,6 @@ Examples:
         /// </summary>
         /// <returns>true if folders should be used, otherwise false.</returns>
         public bool EnableFolders() => GetBoolean(Folders);
-
-        /// <summary>
-        /// Gets a value indicating whether or not shell execute should be used when launching the solution.
-        /// </summary>
-        /// <returns>true if shell executed should be used, otherwise false.</returns>
-        public bool EnableShellExecute() => GetBoolean(ShellExecute, defaultValue: true);
 
         /// <summary>
         /// Gets the Configuration values based on what was specified as command-line arguments.

--- a/src/Microsoft.VisualStudio.SlnGen/Tasks/SlnGenToolTask.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Tasks/SlnGenToolTask.cs
@@ -137,7 +137,6 @@ namespace Microsoft.VisualStudio.SlnGen.Tasks
             commandLineBuilder.AppendSwitchIfNotNull("--launch:", GetPropertyValue(MSBuildPropertyNames.SlnGenLaunchVisualStudio));
             commandLineBuilder.AppendSwitchIfNotNull("--loadprojects:", GetPropertyValue(MSBuildPropertyNames.SlnGenLoadProjects));
             commandLineBuilder.AppendSwitchIfNotNull("--solutionfile:", GetPropertyValue(MSBuildPropertyNames.SlnGenSolutionFileFullPath));
-            commandLineBuilder.AppendSwitchIfNotNull("--useshellexecute:", GetPropertyValue(MSBuildPropertyNames.SlnGenUseShellExecute));
             commandLineBuilder.AppendSwitchIfNotNull("--property:", globalProperties.Count == 0 ? null : string.Join(";", globalProperties.Select(i => $"{i.Key}={i.Value}")));
 
             if (string.Equals(GetPropertyValue(MSBuildPropertyNames.SlnGenDebug), bool.TrueString, StringComparison.OrdinalIgnoreCase))

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "7.2",
+  "version": "8.0",
   "assemblyVersion": "3.0",
   "buildNumberOffset": -1,
   "publicReleaseRefSpec": [


### PR DESCRIPTION
UseShellExecute causes issues when launching process.

 * MSBuild.exe waits for devenv.exe if UseShellExecute is used
* The Visual Studio Version Selector is launched which isn't always correct

Instead, use the instance of Visual Studio for the MSBuild.exe that was found on the PATH which is more precise

Fixes #203, related to #308