### PR TITLE
Fix UsingTask for .NET Core MSBuild 17.0 and above

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.targets
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.targets
@@ -21,11 +21,11 @@
 
   <UsingTask TaskName="Microsoft.VisualStudio.SlnGen.Tasks.SlnGenToolTask"
              AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\net5.0\slngen.dll'))"
-             Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(MSBuildVersion)' &gt;= '16.10.0'" />
+             Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(MSBuildVersion)' &gt;= '16.10.0' And '$(MSBuildVersion)' &lt; '17.0.0'" />
 
   <UsingTask TaskName="Microsoft.VisualStudio.SlnGen.Tasks.SlnGenToolTask"
              AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\net6.0\slngen.dll'))"
-             Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(MSBuildAssemblyVersion)' == '17.0'" />
+             Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(MSBuildVersion)' &gt;= '17.0.0'" />
 
   <Target Name="SlnGen"
           DependsOnTargets="$(SlnGenDependsOn)">


### PR DESCRIPTION
The current conditional logic uses the wrong version of the SlnGen task for .NET Core MSBuild 17.0 and above.

Fixes https://github.com/microsoft/slngen/issues/330