### PR TITLE
Update Contains in ExtensionMethods.cs

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen/ExtensionMethods.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ExtensionMethods.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.SlnGen
         /// <returns>true if the value parameter occurs within this string, or if value is the empty string (""); otherwise, false.</returns>
         public static bool Contains(this string str, string value, StringComparison comparisonType)
         {
-            return value.IndexOf(str, comparisonType) >= 0;
+            return str.IndexOf(value, comparisonType) >= 0;
         }
 
         /// <summary>


### PR DESCRIPTION
Swapped string values to make "Contains" method work correctly.

This fixes the error seen when you type in "slngen **\\*.csproj"

Fixes https://github.com/microsoft/slngen/issues/325