### PR TITLE
Support vsversion-flag through msbuild

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -126,6 +126,7 @@ The following properties only apply when using SlnGen as an MSBuild target.
 | `SlnGenSolutionFileFullPath` | Specifies the full path to the Visual Studio solution file to generate.  By default, the path is the same as the project. | | ProjectPath.sln|
 | `SlnGenDevEnvFullPath` | Specifies a full path to Visual Studio's `devenv.exe` to use when opening the solution file.  By default, SlnGen will launch the program associated with the `.sln` file extension.  However, in some cases you may want to specify a custom path to Visual Studio. | | |
 | `SlnGenGlobalProperties` | Specifies MSBuild properties to set when loading projects and project references. | | `DesignTimeBuild=true;BuildingProject=false` |
+| `SlnGenVSVersion` | Specifies a Visual Studio version to include in the generated solution. | "default" or a version number | | 
 | `SlnGenInheritGlobalProperties` | Indicates whether or not all global variables specified when loading the initial project should be passed around when loading project references. | `true` or `false` | `true` |
 | `SlnGenGlobalPropertiesToRemove` | Specifies a list of inherited global properties to remove when loading projects. | | |
 | `SlnGenBinLog` | Indicates whether or not SlnGen should emit a binary log. | `true` or `false` | `false` |

--- a/src/Microsoft.VisualStudio.SlnGen/MSBuildPropertyNames.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/MSBuildPropertyNames.cs
@@ -90,6 +90,12 @@ namespace Microsoft.VisualStudio.SlnGen
         public const string SlnGenLaunchVisualStudio = nameof(SlnGenLaunchVisualStudio);
 
         /// <summary>
+        /// Visual Studio version to add to the generated solution file.
+        /// Specify "default" to use the same version selection logic launching does.
+        /// </summary>
+        public const string SlnGenVSVersion = nameof(SlnGenVSVersion);
+
+        /// <summary>
         /// Represents the SlnGenLoadProjects property.
         /// </summary>
         public const string SlnGenLoadProjects = nameof(SlnGenLoadProjects);

--- a/src/Microsoft.VisualStudio.SlnGen/Tasks/SlnGenToolTask.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Tasks/SlnGenToolTask.cs
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.SlnGen.Tasks
             // exist, so we use the special value "default" for SlnGenVSVersion to mark that the
             // flag should be given without a value.
             string vsVersion = GetPropertyValue(MSBuildPropertyNames.SlnGenVSVersion);
-            if (vsVersion == SlnGenVSVersionDefault)
+            if (string.Equals(vsVersion, SlnGenVSVersionDefault, StringComparison.OrdinalIgnoreCase))
             {
                 // Specify the switch without a value to trigger version deduction.
                 commandLineBuilder.AppendSwitch("--vsversion");

--- a/src/Microsoft.VisualStudio.SlnGen/Tasks/SlnGenToolTask.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Tasks/SlnGenToolTask.cs
@@ -46,15 +46,15 @@ namespace Microsoft.VisualStudio.SlnGen.Tasks
 
         private static readonly FileInfo ThisAssemblyFileInfo = new FileInfo(Assembly.GetExecutingAssembly().Location);
 
-        private readonly Lazy<IDictionary<string, string>> _globalPropertiesLazy;
-
-        private readonly Lazy<ProjectInstance> _projectInstanceLazy;
-
         /// <summary>
         /// The value for the SlnGenVSVersion property, that will activate version deduction instead of being
         /// treated as a version.
         /// </summary>
         private static readonly string SlnGenVSVersionDefault = "default";
+
+        private readonly Lazy<IDictionary<string, string>> _globalPropertiesLazy;
+
+        private readonly Lazy<ProjectInstance> _projectInstanceLazy;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SlnGenToolTask"/> class.


### PR DESCRIPTION
The command line slngen provides the `--vsversion` flag, but it was not available when using slngen through msbuild. This PR fixes that with the new msbuild property `SlnGenVSVersion`. Its value is passed as the flag.

There is a special case, though. The flag can also be passed without a value. Because an msbuild property that is empty does not exist, I made the special value `default` pass the flag without a value.