### PR TITLE
Fix MSBuild not continuing until Visual Studio closed

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -30,6 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="2.2.0" />
+    <GlobalPackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <GlobalPackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" />

--- a/src/Microsoft.VisualStudio.SlnGen/VisualStudioLauncher.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/VisualStudioLauncher.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.SlnGen
                     {
                         FileName = devEnvFullPath,
                         Arguments = commandLineBuilder.ToString(),
-                        UseShellExecute = false,
+                        UseShellExecute = true,
                     },
                 };
 


### PR DESCRIPTION
Setting `UseShellExecute` to `true` seems to fix the scenario when SlnGen is run as a task but MSBuild does not continue after the task completes since it monitors child processes.

Fixes https://github.com/microsoft/slngen/issues/342