### PR TITLE
Remove System.Configuration.ConfigurationManager from package

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -24,6 +24,7 @@
     <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="17.3.2078" />
     <PackageReference Update="MSBuild.ProjectCreation" Version="8.0.0" />
     <PackageReference Update="Shouldly" Version="4.0.3" />
+    <PackageReference Update="System.Configuration.ConfigurationManager" Version="5.0.0.0" />
     <PackageReference Update="xunit" Version="2.4.1" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" ExcludeAssets="Runtime" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net46\MSBuild.exe" Private="false" Condition="'$(TargetFramework)' == 'net461'" />


### PR DESCRIPTION
MSBuild 17.3 is using a different version and since the package contains System.Configuration.ConfigurationManager, the runtime throws an exception

Fixes #394