### PR TITLE
Add .NET 8 support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,5 +7,6 @@
     <LangVersion>Latest</LangVersion>
     <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
     <NoWarn>$(NoWarn);SA0001;SA1515;SA1005;SA1629;NETSDK1192</NoWarn>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 </Project>

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -57,11 +57,10 @@ stages:
         version: '$(DotNet7Version)'
         includePreviewVersions: true
 
-    - task: UseDotNet@2
+    - script: |
+        powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Channel 8.0 -Quality daily -InstallDir D:\a\_work\_tool\dotnet"
+        dotnet --info
       displayName: 'Install .NET $(DotNet8Version)'
-      inputs:
-        version: '$(DotNet8Version)'
-        includePreviewVersions: true
 
     - task: MicroBuildSigningPlugin@1
       displayName: 'Install MicroBuild Signing Plugin'

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -9,6 +9,7 @@ variables:
   DotNet5Version: '5.x'
   DotNet6Version: '6.x'
   DotNet7Version: '7.x'
+  DotNet8Version: '8.x'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectoryName)\msbuild.binlog"'
   SignType: 'Test'
 
@@ -54,6 +55,12 @@ stages:
       displayName: 'Install .NET $(DotNet7Version)'
       inputs:
         version: '$(DotNet7Version)'
+        includePreviewVersions: true
+
+    - task: UseDotNet@2
+      displayName: 'Install .NET $(DotNet8Version)'
+      inputs:
+        version: '$(DotNet8Version)'
         includePreviewVersions: true
 
     - task: MicroBuildSigningPlugin@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,11 +69,23 @@ jobs:
       version: '$(DotNet7Version)'
       includePreviewVersions: true
 
-  - task: UseDotNet@2
-    displayName: 'Install .NET $(DotNet8Version)'
-    inputs:
-      version: '$(DotNet8Version)'
-      includePreviewVersions: true
+  - script: |
+      powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Channel 8.0 -Quality daily -InstallDir C:\hostedtoolcache\windows\dotnet"
+      dotnet --info
+    displayName: 'Install .NET $(DotNet8Version) (Windows)'
+    condition: eq(variables.osName, 'Windows')
+
+  - script: |
+      curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0 --quality daily --install-dir /opt/hostedtoolcache/dotnet
+      dotnet --info
+    displayName: 'Install .NET $(DotNet8Version) (Linux)'
+    condition: eq(variables.osName, 'Linux')
+
+  - script: |
+      curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0 --quality daily --install-dir /Users/runner/hostedtoolcache/dotnet
+      dotnet --info
+    displayName: 'Install .NET $(DotNet8Version) (MacOS)'
+    condition: eq(variables.osName, 'MacOS')
 
   - task: VSBuild@1
     displayName: 'Build (Visual Studio)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ variables:
   DotNet5Version: '5.x'
   DotNet6Version: '6.x'
   DotNet7Version: '7.x'
+  DotNet8Version: '8.x'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)"'
   SignType: 'Test'
 
@@ -68,6 +69,12 @@ jobs:
       version: '$(DotNet7Version)'
       includePreviewVersions: true
 
+  - task: UseDotNet@2
+    displayName: 'Install .NET $(DotNet8Version)'
+    inputs:
+      version: '$(DotNet8Version)'
+      includePreviewVersions: true
+
   - task: VSBuild@1
     displayName: 'Build (Visual Studio)'
     inputs:
@@ -117,8 +124,16 @@ jobs:
     displayName: 'Run Unit Tests (.NET 7)'
     inputs:
       command: 'test'
-      arguments: '--no-restore --no-build --framework net7.0 /noautorsp $(MSBuildArgs) "/BinaryLogger:$(ArtifactsDirectoryName)/test-net6.0.binlog"'
+      arguments: '--no-restore --no-build --framework net7.0 /noautorsp $(MSBuildArgs) "/BinaryLogger:$(ArtifactsDirectoryName)/test-net7.0.binlog"'
       testRunTitle: '$(osName) .NET 7.0'
+    condition: succeededOrFailed()
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests (.NET 8)'
+    inputs:
+      command: 'test'
+      arguments: '--no-restore --no-build --framework net8.0 /noautorsp $(MSBuildArgs) "/BinaryLogger:$(ArtifactsDirectoryName)/test-net8.0.binlog"'
+      testRunTitle: '$(osName) .NET 8.0'
     condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.0",
+    "version": "7.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }

--- a/src/Microsoft.VisualStudio.SlnGen.Tool/Microsoft.VisualStudio.SlnGen.Tool.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen.Tool/Microsoft.VisualStudio.SlnGen.Tool.csproj
@@ -62,6 +62,14 @@
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true"
                       TargetFramework="net7.0" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.SlnGen\Microsoft.VisualStudio.SlnGen.csproj"
+                      SetTargetFramework="TargetFramework=net8.0"
+                      IncludeAssets="None"
+                      OutputItemType="SlnGenBuildOutput"
+                      PrivateAssets="All"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"
+                      TargetFramework="net8.0" />
   </ItemGroup>
   <Target Name="CopySlnGenToOutputDirectoryAndPackage"
           AfterTargets="PrepareForRun"

--- a/src/Microsoft.VisualStudio.SlnGen.Tool/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.Tool/Program.cs
@@ -74,6 +74,10 @@ namespace Microsoft.VisualStudio.SlnGen
                             framework = "net7.0";
                             break;
 
+                        case "8":
+                            framework = "net8.0";
+                            break;
+
                         default:
                             Console.WriteLine($"SlnGen does not currently support the .NET SDK {developmentEnvironment.DotNetSdkVersion} defined by in global.json.  Please update to the latest version and if you still get this error message, file an issue at https://github.com/microsoft/slngen/issues/new so it can be added.");
 

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/Microsoft.VisualStudio.SlnGen.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/Microsoft.VisualStudio.SlnGen.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);SA1600</NoWarn>
   </PropertyGroup>

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;net472;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net461;net472;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.config</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludeReferenceCopyLocalPathsInBuildOutputInPackage>true</IncludeReferenceCopyLocalPathsInBuildOutputInPackage>
     <IsTool>true</IsTool>
@@ -31,7 +31,7 @@
     <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net472\MSBuild.exe" Private="false" Condition="'$(TargetFramework)' == 'net472'" />
     <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\netcoreapp2.1\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net5.0\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'net5.0'" />
-    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net6.0\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'" />
+    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net6.0\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'" />

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "8.7",
+  "version": "9.0",
   "assemblyVersion": "3.0",
   "buildNumberOffset": -1,
   "publicReleaseRefSpec": [

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "8.6",
+  "version": "8.7",
   "assemblyVersion": "3.0",
   "buildNumberOffset": -1,
   "publicReleaseRefSpec": [


### PR DESCRIPTION
Resolves #424
Pretty much a copy of #362, that added .NET 7 support.


I tested it locally
```
dotnet build
dotnet tool uninstall --global Microsoft.VisualStudio.SlnGen.Tool
dotnet tool install --global Microsoft.VisualStudio.SlnGen.Tool --add-source D:\Development\microsoft-slngen\src\Microsoft.VisualStudio.SlnGen.Tool\bin\Debug --prerelease
```