### PR TITLE
Add support for response files

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/ArgumentsTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/ArgumentsTests.cs
@@ -3,8 +3,7 @@
 // Licensed under the MIT license.
 
 using Shouldly;
-using System;
-using System.Diagnostics;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -13,6 +12,27 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 {
     public class ArgumentsTests : TestBase
     {
+        [Fact]
+        public void ExpandWildcards()
+        {
+            Directory.CreateDirectory(Path.Combine(TestRootPath, "t1", "t2", "t3"));
+            Directory.CreateDirectory(Path.Combine(TestRootPath, "t4"));
+
+            string[] projects = new[]
+            {
+                CreateTempProjectFile("1", string.Empty),
+                CreateTempProjectFile("2"),
+                CreateTempProjectFile("3", Path.Combine("3", "3B")),
+                CreateTempProjectFile("4", Path.Combine("4", "4B", "4C")),
+            };
+
+            File.WriteAllText(GetTempFileName(), string.Empty);
+
+            IEnumerable<string> result = ProgramArguments.ExpandWildcards(new[] { Path.Combine("**", "*.csproj") }, TestRootPath);
+
+            result.ShouldBe(projects, ignoreOrder: true);
+        }
+
         [Fact]
         public void ForwardSlashQuestionMarkDisplaysUsage()
         {
@@ -64,76 +84,27 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         [Fact]
         public void ResponseFile()
         {
-            var root = Path.GetTempPath();
-            var work = Directory.CreateDirectory(Path.Combine(root, Process.GetCurrentProcess().Id.ToString()));
+            TestConsole console = new TestConsole();
 
-            try
+            FileInfo responseFile = new FileInfo(Path.Combine(TestRootPath, "response.rsp"));
+
+            File.WriteAllText(responseFile.FullName, "3.csproj 4.csproj\n5.csproj \"6.csproj\" --ignoreMainProject");
+
+            string[] parseProjects = null;
+            bool? ignoreMainProject = null;
+
+            int exitCode = Program.Execute(new string[] { "1.csproj", "2.csproj", $"@{responseFile.FullName}" }, console, (arguments, _) =>
             {
-                TestConsole console = new TestConsole();
+                parseProjects = arguments.Projects;
+                ignoreMainProject = arguments.IgnoreMainProject;
+                return 42;
+            });
 
-                File.WriteAllText(Path.Combine(work.FullName, "response"), "3.csproj 4.csproj\n5.csproj \"6.csproj\" --ignoreMainProject");
+            exitCode.ShouldBe(42, console.AllOutput);
 
-                var old = Environment.CurrentDirectory;
-                Environment.CurrentDirectory = work.FullName;
-                int exitCode = Program.Execute(new string[] { "1.csproj", "2.csproj", "@response" }, console, (arguments, console1) =>
-                {
-                    arguments.Projects.ShouldBe(new string[] { "1.csproj", "2.csproj", "3.csproj", "4.csproj", "5.csproj", "6.csproj" });
-                    arguments.IgnoreMainProject.ShouldBe(true);
-                    return 42;
-                });
-                Environment.CurrentDirectory = old;
+            parseProjects.ShouldBe(new string[] { "1.csproj", "2.csproj", "3.csproj", "4.csproj", "5.csproj", "6.csproj" });
 
-                exitCode.ShouldBe(42, console.AllOutput);
-            }
-            finally
-            {
-                Directory.Delete(work.FullName, true);
-            }
+            ignoreMainProject.ShouldBe(true);
         }
-
-#if !NETFRAMEWORK
-        [Fact]
-        public void ExpandWildcards()
-        {
-            var root = Path.GetTempPath();
-            var work = Directory.CreateDirectory(Path.Combine(root, Process.GetCurrentProcess().Id.ToString()));
-
-            try
-            {
-                // directory tree
-                _ = Directory.CreateDirectory(Path.Combine(work.FullName, "t1"));
-                _ = Directory.CreateDirectory(Path.Combine(work.FullName, "t1", "t2"));
-                _ = Directory.CreateDirectory(Path.Combine(work.FullName, "t1", "t2", "t3"));
-                _ = Directory.CreateDirectory(Path.Combine(work.FullName, "t4"));
-
-                // sprinkle some files around
-                File.WriteAllText(Path.Combine(work.FullName, "1.csproj"), string.Empty);
-                File.WriteAllText(Path.Combine(work.FullName, "2.csproj"), string.Empty);
-                File.WriteAllText(Path.Combine(work.FullName, "XXX"), string.Empty);
-                File.WriteAllText(Path.Combine(work.FullName, "t1", "3.csproj"), string.Empty);
-                File.WriteAllText(Path.Combine(work.FullName, "t1", "XXX"), string.Empty);
-                File.WriteAllText(Path.Combine(work.FullName, "t1", "t2", "4.csproj"), string.Empty);
-                File.WriteAllText(Path.Combine(work.FullName, "t1", "t2", "5.csproj"), string.Empty);
-                File.WriteAllText(Path.Combine(work.FullName, "t1", "t2", "t3", "6.csproj"), string.Empty);
-
-                var old = Environment.CurrentDirectory;
-                Environment.CurrentDirectory = work.FullName;
-                var result = ProgramArguments.ExpandWildcards(new[] { "**\\*.csproj" });
-                Environment.CurrentDirectory = old;
-
-                var files = result.Select(x => Path.GetFileName(x)).OrderBy<string, string>(x => x).ToArray();
-
-                Assert.Equal(6, files.Length);
-                for (int i = 0; i < files.Length; i++)
-                {
-                    Assert.Equal(files[i], $"{i + 1}.csproj");
-                }
-            }
-            finally
-            {
-                Directory.Delete(work.FullName, true);
-            }
-        }
-#endif
     }
 }

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/TestBase.cs
@@ -27,6 +27,15 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
             GC.SuppressFinalize(this);
         }
 
+        protected string CreateTempProjectFile(string name, string directoryPath = default)
+        {
+            string filePath = GetTempProjectFile(name, directoryPath);
+
+            File.WriteAllText(filePath, "<Project />");
+
+            return filePath;
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)
@@ -45,9 +54,9 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
             return Path.Combine(TestRootPath, $"{Path.GetRandomFileName()}{extension ?? string.Empty}");
         }
 
-        protected string GetTempProjectFile(string name)
+        protected string GetTempProjectFile(string name, string directoryPath = default)
         {
-            DirectoryInfo projectDirectory = Directory.CreateDirectory(Path.Combine(TestRootPath, name));
+            DirectoryInfo projectDirectory = Directory.CreateDirectory(Path.Combine(TestRootPath, directoryPath ?? name));
 
             return Path.Combine(projectDirectory.FullName, $"{name}.csproj");
         }

--- a/src/Microsoft.VisualStudio.SlnGen/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.cs
@@ -246,6 +246,28 @@ namespace Microsoft.VisualStudio.SlnGen
             return 0;
         }
 
+        /// <summary>
+        /// Writes the specified error to the console.
+        /// </summary>
+        /// <param name="console">An <see cref="IConsole" /> to write the error to.</param>
+        /// <param name="message">The message to write to <see cref="Console.Error" />.</param>
+        /// <param name="args">An array of objects to write using <see cref="message" />.</param>
+        internal static void WriteError(IConsole console, string message, params object[] args)
+        {
+            if (console is null)
+            {
+                throw new ArgumentNullException(nameof(console));
+            }
+
+            console.BackgroundColor = ConsoleColor.Black;
+
+            console.ForegroundColor = ConsoleColor.Red;
+
+            console.Error.WriteLine(message, args);
+
+            console.ResetColor();
+        }
+
         private static int Execute(string[] args, IConsole console)
         {
             try
@@ -294,7 +316,7 @@ namespace Microsoft.VisualStudio.SlnGen
             {
                 TelemetryClient.PostException(e);
 
-                Utility.WriteError(e.ToString());
+                WriteError(console, e.ToString());
 
                 return 2;
             }

--- a/src/Microsoft.VisualStudio.SlnGen/ProgramArguments.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ProgramArguments.cs
@@ -432,33 +432,26 @@ Examples:
             return result.Count > 0;
         }
 
-        internal static IEnumerable<string> ExpandWildcards(IEnumerable<string> paths)
+        internal static IEnumerable<string> ExpandWildcards(IEnumerable<string> paths, string directoryPath = default)
         {
-            List<string> results = new List<string>();
-            List<string> pathsWithWildcards = new List<string>();
-
             foreach (string path in paths)
             {
-                if (path.Contains("*", StringComparison.OrdinalIgnoreCase))
+                if (path.Contains("*", StringComparison.OrdinalIgnoreCase) || path.Contains("?", StringComparison.OrdinalIgnoreCase))
                 {
-                    pathsWithWildcards.Add(path);
+                    Matcher matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
+
+                    matcher.AddInclude(path);
+
+                    foreach (string expandedPath in matcher.GetResultsInFullPath(directoryPath ?? Environment.CurrentDirectory))
+                    {
+                        yield return expandedPath;
+                    }
                 }
                 else
                 {
-                    results.Add(path);
+                    yield return path;
                 }
             }
-
-            if (pathsWithWildcards.Any())
-            {
-                Matcher matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
-
-                matcher.AddIncludePatterns(pathsWithWildcards);
-
-                results.AddRange(matcher.GetResultsInFullPath(Environment.CurrentDirectory));
-            }
-
-            return results;
         }
 
         private bool GetBoolean(string[] values, bool defaultValue = false)

--- a/src/Microsoft.VisualStudio.SlnGen/ProgramArguments.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ProgramArguments.cs
@@ -14,6 +14,7 @@ namespace Microsoft.VisualStudio.SlnGen
     /// <summary>
     /// Represents the command-line arguments for this application.
     /// </summary>
+    [Command(ResponseFileHandling = ResponseFileHandling.ParseArgsAsSpaceSeparated)]
     public sealed class ProgramArguments
     {
         /// <summary>
@@ -207,12 +208,12 @@ Examples:
         public string[] Platform { get; set; }
 
         /// <summary>
-        /// Gets or sets the full path to the project to generate a solution for.
+        /// Gets or sets the full path to the projects to generate a solution for.
         /// </summary>
         [Argument(
             0,
-            Name = "project path",
-            Description = "An optional path to a project which can include wildcards like **\\*.csproj or directories which contain projects files.  If not specified, all projects in the current directory will be used.")]
+            Name = "project paths",
+            Description = "Optional path to one or more projects.  Paths can include wildcards like **\\*.csproj or directories which contain projects files.  If not specified, all projects in the current directory will be used.")]
         public string[] Projects { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/microsoft/slngen/issues/426

1. Add CommandAttribute to specify response files are allowed. Note that it's optional, so it wasn't there before, and the only effect should be to apply this setting.
2. Add test.
3. Unrelated, correct usage text for project paths. Clearly, more than one is allowed.

Incidentally, Microsoft.VisualStudio.SlnGen.Tool.csproj still targets .NET 5.0, which is out of support. I suggest to update it to 6.0.