### PR TITLE
Fixed #444 Multiple projects depending on the same shared items causes an error

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen/ProjectLoading/ProjectGraphProjectLoader.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ProjectLoading/ProjectGraphProjectLoader.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.SlnGen.ProjectLoading
                             _ = CreateProject(projectPath.FullName, globalProperties, projectCollection);
                         }
                     }
-                    else if (importPath.EndsWith(ProjectFileExtensions.VcxItems))
+                    else if (importPath.EndsWith(ProjectFileExtensions.VcxItems) && !LoadedProjects.ContainsKey(importPath))
                     {
                         _ = CreateProject(importPath, globalProperties, projectCollection);
                     }


### PR DESCRIPTION
When multiple projects in the graph referred to the same shared items project, it was tried to add to `LoadedProjects` another time, causing it to throw `System.InvalidOperationException: An equivalent project (a project with the same global properties and tools version) is already present in the project collection..`

Solution:
Don't call `CreateProject` on the imported project if it's already in `LoadedProjects`.

Fixes #444 