### PR TITLE
Fix dotnet sdk resolution

### DIFF
--- a/src/Shared/DevelopmentEnvironment.cs
+++ b/src/Shared/DevelopmentEnvironment.cs
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.SlnGen
 
             if (!DotNetCoreSdkResolver.TryResolveDotNetCoreSdk(environmentProvider, dotnetFileInfo, out DirectoryInfo dotnetCoreSdkDirectoryInfo))
             {
-                return new DevelopmentEnvironment(string.Empty);
+                return new DevelopmentEnvironment("Could not resolve dotnet sdk path.");
             }
 
             DevelopmentEnvironment developmentEnvironment = new DevelopmentEnvironment

--- a/src/Shared/DotNetCoreSdkResolver.cs
+++ b/src/Shared/DotNetCoreSdkResolver.cs
@@ -25,16 +25,14 @@ namespace Microsoft.VisualStudio.SlnGen
         /// </summary>
         /// <param name="environmentProvider">An <see cref="IEnvironmentProvider" /> to use when accessing the environment.</param>
         /// <param name="dotnetFileInfo">A <see cref="FileInfo" /> representing the path to dotnet.exe.</param>
-        /// <param name="basePath">Receives the root path of the .NET Core SDK if one is found.</param>
+        /// <param name="developmentEnvironment">Receives a <see cref="DevelopmentEnvironment" /> instance containing details of the .NET Core SDK if one is found.</param>
         /// <returns><code>true</code> if a .NET Core SDK could be located, otherwise <code>false</code>.</returns>
-        public static bool TryResolveDotNetCoreSdk(IEnvironmentProvider environmentProvider, FileInfo dotnetFileInfo, out DirectoryInfo basePath)
+        public static bool TryResolveDotNetCoreSdk(IEnvironmentProvider environmentProvider, FileInfo dotnetFileInfo, out DevelopmentEnvironment developmentEnvironment)
         {
             if (environmentProvider is null)
             {
                 throw new ArgumentNullException(nameof(environmentProvider));
             }
-
-            basePath = null;
 
             string parsedBasePath = null;
 
@@ -78,11 +76,15 @@ namespace Microsoft.VisualStudio.SlnGen
             {
                 if (!process.Start())
                 {
+                    developmentEnvironment = new DevelopmentEnvironment("Failed to resolve the .NET SDK.  Verify the 'dotnet' command is available on the PATH.");
+
                     return false;
                 }
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                developmentEnvironment = new DevelopmentEnvironment("Failed to resolve the .NET SDK.  An exception occurred running the 'dotnet --info' command: ", e.ToString());
+
                 return false;
             }
 
@@ -109,23 +111,34 @@ namespace Microsoft.VisualStudio.SlnGen
                 }
             }
 
+            DirectoryInfo basePath;
+
             if (!string.IsNullOrWhiteSpace(parsedBasePath))
             {
                 basePath = new DirectoryInfo(parsedBasePath);
-
-                return true;
             }
-
-            (string sdkDirectory, string globalJsonPath, string requestedVersionNumber) = ResolveSdk(environmentProvider, dotnetFileInfo.Directory);
-
-            if (!string.IsNullOrWhiteSpace(sdkDirectory))
+            else
             {
-                basePath = new DirectoryInfo(sdkDirectory);
+                (string sdkDirectory, string globalJsonPath, string requestedVersionNumber) = ResolveSdk(environmentProvider, dotnetFileInfo.Directory);
 
-                return true;
+                if (string.IsNullOrWhiteSpace(sdkDirectory))
+                {
+                    developmentEnvironment = new DevelopmentEnvironment($"Failed to resolve the .NET SDK.  The 'dotnet --info' command returned the path '{parsedBasePath}' and the .NET SDK resolver returned the path '{sdkDirectory}', a global.json path of '{globalJsonPath}', and a requested version of '{requestedVersionNumber}'.");
+
+                    return false;
+                }
+
+                basePath = new DirectoryInfo(sdkDirectory);
             }
 
-            return false;
+            developmentEnvironment = new DevelopmentEnvironment
+            {
+                DotNetSdkVersion = basePath.Name,
+                DotNetSdkMajorVersion = basePath.Name.Substring(0, basePath.Name.IndexOf(".", StringComparison.OrdinalIgnoreCase)),
+                MSBuildDll = new FileInfo(Path.Combine(basePath.FullName, "MSBuild.dll")),
+            };
+
+            return true;
         }
 
         private static (string sdkDirectory, string globalJsonPath, string requestedVersion) ResolveSdk(IEnvironmentProvider environmentProvider, DirectoryInfo dotnetExeDirectory)
@@ -133,6 +146,28 @@ namespace Microsoft.VisualStudio.SlnGen
             string sdkDirectory = null;
             string globalJsonPath = null;
             string requestedVersionNumber = null;
+
+            // Set the console color to red in case the .NET SDK resolver logs any errors to the console
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.BackgroundColor = ConsoleColor.Black;
+
+            try
+            {
+                if (Utility.RunningOnWindows)
+                {
+                    Windows.ResolveSdk(dotnetExeDirectory.FullName, environmentProvider.CurrentDirectory, 0 /* None */, HandleResolveSdkResult);
+                }
+                else
+                {
+                    Unix.ResolveSdk(dotnetExeDirectory.FullName, environmentProvider.CurrentDirectory, 0 /* None */, HandleResolveSdkResult);
+                }
+
+                return (sdkDirectory, globalJsonPath, requestedVersionNumber);
+            }
+            finally
+            {
+                Console.ResetColor();
+            }
 
             void HandleResolveSdkResult(int key, string value)
             {
@@ -151,17 +186,6 @@ namespace Microsoft.VisualStudio.SlnGen
                         break;
                 }
             }
-
-            if (Utility.RunningOnWindows)
-            {
-                Windows.ResolveSdk(dotnetExeDirectory.FullName, environmentProvider.CurrentDirectory, 0 /* None */, HandleResolveSdkResult);
-            }
-            else
-            {
-                Unix.ResolveSdk(dotnetExeDirectory.FullName, environmentProvider.CurrentDirectory, 0 /* None */, HandleResolveSdkResult);
-            }
-
-            return (sdkDirectory, globalJsonPath, requestedVersionNumber);
         }
 
         private static class Unix


### PR DESCRIPTION
Fixes #453 

The initial fix for 453 only resolved passing the path which allowed it to find the proper location for the SDKs.

However, the actual outcome from the result of calling `hostfxr_resolve_sdk2` was ignored and not passed back to the calling function to use with the tool.

The error message was also returned as an empty string and thus was not showing up as the root cause either.

I validated with a private package in our CI that:
1) By returning an error message string this was indeed the path being taken on both our Linux and Windows servers
2) That the following patch allows them to get through this code path properly.

I also linked to the .NET repo which contains the native method's documentation as it does things like calls out the CharSet difference, the behavior of the return, and the values for the callback.

Wasn't sure if there was logging available here, could be a good thing for the future, as you can get the resolved version if `global.json` was used and print that out to the console.

Could also be good to add smoke tests which use the nuget package to install and run the tool in a scenario in your CI vs. just running the unit tests against the solution file scenarios?