### PR TITLE
Freeze .NET 8 runtime version requirement

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -10,6 +10,8 @@ variables:
   DotNet6Version: '6.x'
   DotNet7Version: '7.x'
   DotNet8Version: '8.x'
+  # Not using "--channel 8.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
+  DotNet8InstallArgs: '-version 8.0.100-alpha.1.23061.8'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectoryName)\msbuild.binlog"'
   SignType: 'Test'
 
@@ -58,7 +60,7 @@ stages:
         includePreviewVersions: true
 
     - script: |
-        powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Channel 8.0 -Quality daily -InstallDir D:\a\_work\_tool\dotnet"
+        powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) $(DotNet8InstallArgs) -InstallDir D:\a\_work\_tool\dotnet"
         dotnet --info
       displayName: 'Install .NET $(DotNet8Version)'
 


### PR DESCRIPTION
Resolves #456
Addendum to #457


I didn't realise the was another build pipeline... The latest tool is still unusable unless the latest .NET 8 is installed:
![image](https://user-images.githubusercontent.com/4403806/227828390-ad2f9c34-3c9f-493c-a47a-5833d63475c0.png)
