### PR TITLE
Adopt Microsoft.Build.Traversal for skipping projects when building the solution

### DIFF
--- a/Directory.Solution.props
+++ b/Directory.Solution.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="Sdk.props" Sdk="Microsoft.Build.Traversal" />
+</Project>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -1,28 +1,8 @@
-<Project InitialTargets="RemoveProjectsToSkip">
-  <!--
-    RemoveProjectsToSkip removes projects from the solution if they can't be built.  It determines
-    this by calling the ShouldSkipProject target for each project so it can indicate if a project
-    cannot be built and why.
-  -->
-  <Target Name="RemoveProjectsToSkip">
-    <MSBuild BuildInParallel="True"
-             Properties="BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionPath=$(SolutionPath);"
-             SkipNonexistentProjects="%(ProjectReference.SkipNonexistentProjects)"
-             Projects="@(ProjectReference)"
-             Targets="ShouldSkipProject">
-      <Output TaskParameter="TargetOutputs"
-              ItemName="ProjectToSkip" />
-    </MSBuild>
-    <ItemGroup>
-      <ProjectReference Remove="@(ProjectToSkip)" />
-    </ItemGroup>
-    <Message Text="Skipping project &quot;%(ProjectToSkip.Identity)&quot;. %(ProjectToSkip.Message)"
-             Condition="@(ProjectToSkip->Count()) > 0 And '$(MSBuildRestoreSessionId)' == ''"
-             Importance="High" />
-  </Target>
-
+<Project>
   <PropertyGroup>
     <!-- The target framework 'net5.0' is out of support and will not receive security updates in the future. -->
     <CheckEolTargetFramework Condition="'$(TargetFramework)' == 'net5.0'">false</CheckEolTargetFramework>
   </PropertyGroup>
+  
+  <Import Project="Sdk.targets" Sdk="Microsoft.Build.Traversal" />
 </Project>

--- a/global.json
+++ b/global.json
@@ -3,5 +3,8 @@
     "version": "7.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
+  },
+  "msbuild-sdks": {
+    "Microsoft.Build.Traversal": "4.0.0"
   }
 }


### PR DESCRIPTION
I've added the proof-of-concept developed here directly into Microsoft.Build.Traversal: https://github.com/microsoft/MSBuildSdks/pull/439