### PR TITLE
TEMP: hack until .NET 8 is shipped and/or .NET 9 SDK is coherent

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen.Tool/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.Tool/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 //
 // Licensed under the MIT license.
 
@@ -77,6 +77,8 @@ namespace Microsoft.VisualStudio.SlnGen
                             break;
 
                         case "8":
+                        // TEMP: hack until .NET 8 is shipped and/or .NET 9 SDK is coherent
+                        case "9":
                             framework = "net8.0";
                             break;
 


### PR DESCRIPTION
I tested it locally:
```
dotnet build
dotnet tool uninstall --global Microsoft.VisualStudio.SlnGen.Tool
dotnet tool install --global Microsoft.VisualStudio.SlnGen.Tool --add-source D:\Development\microsoft-slngen\src\Microsoft.VisualStudio.SlnGen.Tool\bin\Debug --prerelease
```

## Before:
```
PS D:\Development\dotnet-extensions> .\restore.cmd -vs * -nolaunch

SlnGen does not currently support the .NET SDK 9.0.100-alpha.1.23464.17 defined by in global.json.  Please update to the latest version and if you still get this error message, file an issue at https://github.com/microsoft/slngen/issues/new so it can be added.
Failed to generate the solution.
```

## After:
```
PS D:\Development\dotnet-extensions> .\restore.cmd -vs * -nolaunch

Build started 25/09/2023 10:58:46 AM.
Generating solution for project "D:\Development\dotnet-extensions\test\TestUtilities\TestUtilities.csproj"
Generating solution for project "D:\Development\dotnet-extensions\src\Analyzers\Microsoft.Analyzers.Extra\Microsoft.Analyzers.Extra.csproj"
Generating solution for project "D:\Development\dotnet-extensions\src\Analyzers\Microsoft.Analyzers.Local\Microsoft.Analyzers.Local.csproj"
Generating solution for project "D:\Development\dotnet-extensions\src\Generators\Microsoft.Gen.AutoClient\Microsoft.Gen.AutoClient.csproj"
....
```