### PR TITLE
Emit warning for projects detected in multiple drives

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Xunit;
 
 namespace Microsoft.VisualStudio.SlnGen.UnitTests
@@ -106,7 +107,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             string solutionFilePath = GetTempFileName();
 
-            slnFile.Save(solutionFilePath, useFolders: false);
+            slnFile.Save(solutionFilePath, useFolders: false, new TestLogger());
 
             SolutionFile solutionFile = SolutionFile.Parse(solutionFilePath);
 
@@ -193,7 +194,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             string solutionFilePath = GetTempFileName();
 
-            slnFile.Save(solutionFilePath, useFolders: false, alwaysBuild: false);
+            slnFile.Save(solutionFilePath, useFolders: false, new TestLogger(), alwaysBuild: false);
 
             SolutionFile solutionFile = SolutionFile.Parse(solutionFilePath);
 
@@ -232,7 +233,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             string solutionFilePath = GetTempFileName();
 
-            slnFile.Save(solutionFilePath, useFolders: false);
+            slnFile.Save(solutionFilePath, useFolders: false, new TestLogger());
 
             SolutionFile solutionFile = SolutionFile.Parse(solutionFilePath);
 
@@ -314,7 +315,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             string solutionFilePath = GetTempFileName();
 
-            slnFile.Save(solutionFilePath, useFolders: false);
+            slnFile.Save(solutionFilePath, useFolders: false, new TestLogger());
 
             SolutionFile solutionFile = SolutionFile.Parse(solutionFilePath);
 
@@ -354,7 +355,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             slnFile.AddProjects(new[] { project });
 
-            slnFile.Save(path, useFolders: false);
+            slnFile.Save(path, useFolders: false, new TestLogger());
 
             SlnFile.TryParseExistingSolution(path, out Guid solutionGuid, out _).ShouldBeTrue();
 
@@ -554,7 +555,7 @@ EndGlobal
 
             string path = Path.GetTempFileName();
 
-            slnFile.Save(path, useFolders: false);
+            slnFile.Save(path, useFolders: false, new TestLogger());
 
             string directoryName = new DirectoryInfo(TestRootPath).Name;
 
@@ -636,7 +637,7 @@ EndGlobal
 
             slnFile.AddProjects(projects, new Dictionary<string, Guid>(), projects[1].FullPath);
             slnFile.AddSolutionItems(solutionItems);
-            slnFile.Save(solutionFilePath, useFolders: false);
+            slnFile.Save(solutionFilePath, useFolders: false, new TestLogger());
 
             SolutionFile s = SolutionFile.Parse(solutionFilePath);
 
@@ -672,7 +673,7 @@ EndGlobal
 
             SlnFile slnFile = new SlnFile();
 
-            slnFile.Save(fullPath, useFolders: false);
+            slnFile.Save(fullPath, useFolders: false, new TestLogger());
 
             File.Exists(fullPath).ShouldBeTrue();
         }
@@ -891,7 +892,7 @@ EndGlobal
 
             slnFile.AddProjects(projects, new Dictionary<string, Guid>(), projects[1].FullPath);
             slnFile.AddSolutionItems(solutionItems);
-            slnFile.Save(solutionFilePath, true);
+            slnFile.Save(solutionFilePath, true, new TestLogger());
 
             SolutionFile solutionFile = SolutionFile.Parse(solutionFilePath);
 
@@ -949,7 +950,7 @@ EndGlobal
 
             slnFile.AddProjects(projects, new Dictionary<string, Guid>());
             slnFile.AddSolutionItems(solutionItems);
-            slnFile.Save(solutionFilePath, true);
+            slnFile.Save(solutionFilePath, true, new TestLogger());
 
             SolutionFile solutionFile = SolutionFile.Parse(solutionFilePath);
 
@@ -1016,7 +1017,7 @@ EndGlobal
 
             slnFile.AddProjects(projects, new Dictionary<string, Guid>(), ignoreMainProject ? null : projects[1].FullPath);
             slnFile.AddSolutionItems(solutionItems);
-            slnFile.Save(solutionFilePath, useFolders: true, collapseFolders: collapseFolders);
+            slnFile.Save(solutionFilePath, useFolders: true, new TestLogger(), collapseFolders: collapseFolders);
 
             SolutionFile solutionFile = SolutionFile.Parse(solutionFilePath);
 
@@ -1072,7 +1073,7 @@ EndGlobal
                 SolutionGuid = new Guid("{6370DE27-36B7-44AE-B47A-1ECF4A6D740A}"),
             };
 
-            slnFile.Save(solutionFilePath, useFolders: false);
+            slnFile.Save(solutionFilePath, useFolders: false, new TestLogger());
 
             File.ReadAllText(solutionFilePath).ShouldBe(
                 @"Microsoft Visual Studio Solution File, Format Version 12.00
@@ -1109,7 +1110,7 @@ EndGlobal
             slnFile.AddSolutionItems("docs", new[] { Path.Combine(this.TestRootPath, "README.md") });
 
             // Act
-            slnFile.Save(solutionFilePath, useFolders: false);
+            slnFile.Save(solutionFilePath, useFolders: false, new TestLogger());
 
             // Assert
             File.ReadAllText(solutionFilePath).ShouldBe(
@@ -1135,6 +1136,48 @@ EndGlobal
                 StringCompareShould.IgnoreLineEndings);
         }
 
+        [Fact]
+        public void EmitWarningForProjectsOnMultipleDrives()
+        {
+            bool isWindowsPlatform = Utility.RunningOnWindows;
+            SlnProject projectA = new ()
+            {
+                Name = "ProjectA",
+                FullPath = isWindowsPlatform ? @"A:\ProjectA\ProjectA.vcxitems" : "/dev/ProjectA/ProjectA.vcxitems",
+                ProjectGuid = new Guid("C95D800E-F016-4167-8E1B-1D3FF94CE2E2"),
+                ProjectTypeGuid = new Guid("88152E7E-47E3-45C8-B5D3-DDB15B2F0435"),
+            };
+
+            SlnProject projectB = new ()
+            {
+                Name = "ProjectB",
+                FullPath = isWindowsPlatform ? @"B:\ProjectB\ProjectB.vcxitems" : "/mnt/ProjectB/ProjectB.vcxitems",
+                ProjectGuid = new Guid("EAD108BE-AC70-41E6-A8C3-450C545FDC0E"),
+                ProjectTypeGuid = new Guid("F38341C3-343F-421A-AE68-94CD9ADCD32F"),
+            };
+
+            TestLogger logger = new ();
+            SlnFile slnFile = new ();
+            SlnProject[] projects = new[] { projectA, projectB };
+            string solutionFilePath = GetTempFileName();
+            StringBuilderTextWriter writer = new (new StringBuilder(), new List<string>());
+
+            slnFile.AddProjects(projects);
+            slnFile.Save(solutionFilePath, writer, useFolders: true, logger);
+
+            logger.Errors.Count.ShouldBe(0);
+
+            if (isWindowsPlatform)
+            {
+                logger.Warnings.Count.ShouldBe(1);
+                logger.Warnings.FirstOrDefault().Message.ShouldContain("Detected two or more projects on multiple drives");
+            }
+            else
+            {
+                logger.Warnings.Count.ShouldBe(0);
+            }
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -1155,7 +1198,7 @@ EndGlobal
             };
 
             slnFile.AddProjects(new[] { slnProject });
-            slnFile.Save(solutionFilePath, useFolders: false);
+            slnFile.Save(solutionFilePath, useFolders: false, new TestLogger());
 
             ValidateProjectInSolution(
                 (slnProject, projectInSolution) =>
@@ -1178,7 +1221,7 @@ EndGlobal
             SlnFile slnFile = new SlnFile();
 
             slnFile.AddProjects(projects);
-            slnFile.Save(solutionFilePath, useFolders);
+            slnFile.Save(solutionFilePath, useFolders, new TestLogger());
 
             SolutionFile solutionFile = SolutionFile.Parse(solutionFilePath);
 

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
@@ -1159,23 +1159,15 @@ EndGlobal
             TestLogger logger = new ();
             SlnFile slnFile = new ();
             SlnProject[] projects = new[] { projectA, projectB };
-            string solutionFilePath = GetTempFileName();
+            string solutionFilePath = @$"X:\{Path.GetRandomFileName()}";
             StringBuilderTextWriter writer = new (new StringBuilder(), new List<string>());
 
             slnFile.AddProjects(projects);
             slnFile.Save(solutionFilePath, writer, useFolders: true, logger);
 
             logger.Errors.Count.ShouldBe(0);
-
-            if (isWindowsPlatform)
-            {
-                logger.Warnings.Count.ShouldBe(1);
-                logger.Warnings.FirstOrDefault().Message.ShouldContain("Detected two or more projects on multiple drives");
-            }
-            else
-            {
-                logger.Warnings.Count.ShouldBe(0);
-            }
+            logger.Warnings.Count.ShouldBe(1);
+            logger.Warnings.FirstOrDefault().Message.ShouldContain("Detected folder on a different drive from the root solution path");
         }
 
         [Theory]

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/StringBuilderTextWriter.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/StringBuilderTextWriter.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+//
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.VisualStudio.SlnGen.UnitTests
+{
+    /// <summary>
+    /// Extends <see cref="TextWriter" /> for unit tests to capture writing text.
+    /// </summary>
+    public class StringBuilderTextWriter : TextWriter
+    {
+        private readonly List<string> _lines;
+        private readonly StringBuilder _lineStringBuilder = new StringBuilder();
+        private readonly StringBuilder _stringBuilder;
+
+        public StringBuilderTextWriter(StringBuilder stringBuilder, List<string> lines)
+        {
+            _stringBuilder = stringBuilder;
+            _lines = lines;
+        }
+
+        public override Encoding Encoding => Encoding.Unicode;
+
+        public override void Write(char value)
+        {
+            _lineStringBuilder.Append(value);
+
+            _stringBuilder.Append(value);
+
+            if (value == '\n')
+            {
+                _lines.Add(_lineStringBuilder.ToString());
+
+                _lineStringBuilder.Clear();
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/TestConsole.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/TestConsole.cs
@@ -63,34 +63,5 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         public void ResetColor()
         {
         }
-
-        private class StringBuilderTextWriter : TextWriter
-        {
-            private readonly List<string> _lines;
-            private readonly StringBuilder _lineStringBuilder = new StringBuilder();
-            private readonly StringBuilder _stringBuilder;
-
-            public StringBuilderTextWriter(StringBuilder stringBuilder, List<string> lines)
-            {
-                _stringBuilder = stringBuilder;
-                _lines = lines;
-            }
-
-            public override Encoding Encoding => Encoding.Unicode;
-
-            public override void Write(char value)
-            {
-                _lineStringBuilder.Append(value);
-
-                _stringBuilder.Append(value);
-
-                if (value == '\n')
-                {
-                    _lines.Add(_lineStringBuilder.ToString());
-
-                    _lineStringBuilder.Clear();
-                }
-            }
-        }
     }
 }

--- a/src/Microsoft.VisualStudio.SlnGen/SlnFolder.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnFolder.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.SlnGen
         }
 
         /// <summary>
-        /// Gets the <see cref="Guid" /> of the folder.
+        /// Gets or sets the <see cref="Guid" /> of the folder.
         /// </summary>
         public Guid FolderGuid { get; set; }
 


### PR DESCRIPTION
Use absolute instead of relative paths when the folder in a solution file is on a different drive from the root solution path and emit warning, as discussed in #512.