### PR TITLE
Remove TargetDotNet8 conditions from net8.0 TFM 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,6 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true'">true</ContinuousIntegrationBuild>
     <NoWarn>$(NoWarn);NETSDK1213</NoWarn>
-    <TargetDotNet8 Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</TargetDotNet8>
     <TargetDotNet9 Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</TargetDotNet9>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.SlnGen.Tool/Microsoft.VisualStudio.SlnGen.Tool.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen.Tool/Microsoft.VisualStudio.SlnGen.Tool.csproj
@@ -6,7 +6,6 @@
     <ToolCommandName>slngen</ToolCommandName>
     <RollForward>LatestMajor</RollForward>
     <_GetChildProjectCopyToPublishDirectoryItems>false</_GetChildProjectCopyToPublishDirectoryItems>
-    <TargetDotNet8 Condition="'$(TargetDotNet8)' == '' And $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '8.0'))">true</TargetDotNet8>
     <TargetDotNet9 Condition="'$(TargetDotNet9)' == '' And $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))">true</TargetDotNet9>
   </PropertyGroup>
   <Import Project="..\Shared\Shared.props" />
@@ -55,8 +54,7 @@
                       PrivateAssets="All"
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true"
-                      TargetFramework="net8.0"
-                      Condition="'$(TargetDotNet8)' == 'true'" />
+                      TargetFramework="net8.0" />
     <ProjectReference Include="..\Microsoft.VisualStudio.SlnGen\Microsoft.VisualStudio.SlnGen.csproj"
                       SetTargetFramework="TargetFramework=net9.0"
                       IncludeAssets="None"

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/Microsoft.VisualStudio.SlnGen.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/Microsoft.VisualStudio.SlnGen.UnitTests.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetDotNet8 Condition="'$(TargetDotNet8)' == '' And $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '8.0'))">true</TargetDotNet8>
     <TargetDotNet9 Condition="'$(TargetDotNet9)' == '' And $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))">true</TargetDotNet9>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetDotNet8)' == 'true'">$(TargetFrameworks);net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetDotNet9)' == 'true'">$(TargetFrameworks);net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);SA1600</NoWarn>

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetDotNet8 Condition="'$(TargetDotNet8)' == '' And $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '8.0'))">true</TargetDotNet8>
     <TargetDotNet9 Condition="'$(TargetDotNet9)' == '' And $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))">true</TargetDotNet9>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;net472;net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetDotNet8)' == 'true'">$(TargetFrameworks);net8.0</TargetFrameworks>
+    <TargetFrameworks>net461;net472;net6.0;net7.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetDotNet9)' == 'true'">$(TargetFrameworks);net9.0</TargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.config</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludeReferenceCopyLocalPathsInBuildOutputInPackage>true</IncludeReferenceCopyLocalPathsInBuildOutputInPackage>


### PR DESCRIPTION
As discussed in #513, remove the `TargetDotNet8` conditions from TFM once .NET 8 is GA.