### PR TITLE
Use MSBuild properties to update solution file name and enable folder creation

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
@@ -490,6 +490,87 @@ EndGlobal
         }
 
         [Fact]
+        public void TestSlnGenProjectNamePropertyForSolutionName()
+        {
+            Project[] projects =
+            {
+                ProjectCreator.Templates.SdkCsproj(path: GetTempProjectFile("ProjectA"))
+                    .Property("SlnGenProjectName", "RandomComponent")
+                    .Save(),
+            };
+
+            string solutionFilePath = GetSolutionFilePath(projects);
+            solutionFilePath.ShouldContain("RandomComponent.sln");
+        }
+
+        [Fact]
+        public void TestDefaultSolutionName()
+        {
+            Project[] projects =
+            {
+                ProjectCreator.Templates.SdkCsproj(path: GetTempProjectFile("ProjectA")).Save(),
+            };
+
+            string solutionFilePath = GetSolutionFilePath(projects);
+            solutionFilePath.ShouldContain("ProjectA.sln");
+        }
+
+        [Fact]
+        public void TestSlnGenFoldersPropertyToEnableFolderCreation()
+        {
+            Project projectA = ProjectCreator.Templates.SdkCsproj(path: GetTempProjectFile("ProjectA"))
+                .Property("SlnGenFolders", "true")
+                .Save();
+
+            Project projectB = ProjectCreator.Templates.SdkCsproj(path: GetTempProjectFile("ProjectB", directoryPath: "testB"))
+                .Property("SlnGenFolders", "true")
+                .Save();
+
+            Project projectC = ProjectCreator.Templates.SdkCsproj(path: GetTempProjectFile("ProjectC", directoryPath: "testC"))
+                .Property("SlnGenFolders", "true")
+                .Save();
+
+            string solutionFilePath = GetSolutionFilePath(new Project[] { projectA, projectB, projectC });
+            string contents = File.ReadAllText(solutionFilePath);
+            contents.ShouldContain("\"..\\testB\",");
+            contents.ShouldContain("\"..\\testC\",");
+        }
+
+        [Fact]
+        public void TestSlnGenFoldersPropertyToDisableFolderCreation()
+        {
+            Project projectA = ProjectCreator.Templates.SdkCsproj(path: GetTempProjectFile("ProjectA"))
+                .Property("SlnGenFolders", "false")
+                .Save();
+
+            Project projectB = ProjectCreator.Templates.SdkCsproj(path: GetTempProjectFile("ProjectB", directoryPath: "testB"))
+                .Property("SlnGenFolders", "false")
+                .Save();
+
+            Project projectC = ProjectCreator.Templates.SdkCsproj(path: GetTempProjectFile("ProjectC", directoryPath: "testC"))
+                .Property("SlnGenFolders", "false")
+                .Save();
+
+            string solutionFilePath = GetSolutionFilePath(new Project[] { projectA, projectB, projectC });
+            string contents = File.ReadAllText(solutionFilePath);
+            contents.ShouldNotContain("\"..\\testB\",");
+            contents.ShouldNotContain("\"..\\testC\",");
+        }
+
+        [Fact]
+        public void TestNoFolderCreation()
+        {
+            Project projectA = ProjectCreator.Templates.SdkCsproj(path: GetTempProjectFile("ProjectA")).Save();
+            Project projectB = ProjectCreator.Templates.SdkCsproj(path: GetTempProjectFile("ProjectB", directoryPath: "testB")).Save();
+            Project projectC = ProjectCreator.Templates.SdkCsproj(path: GetTempProjectFile("ProjectC", directoryPath: "testC")).Save();
+
+            string solutionFilePath = GetSolutionFilePath(new Project[] { projectA, projectB, projectC });
+            string contents = File.ReadAllText(solutionFilePath);
+            contents.ShouldNotContain("\"..\\testB\",");
+            contents.ShouldNotContain("\"..\\testC\",");
+        }
+
+        [Fact]
         public void ProjectConfigurationPlatformOrderingSameAsProjects()
         {
             const string projectTypeGuid = "{7E0F1516-6200-48BD-83FC-3EFA3AB4A574}";
@@ -1169,6 +1250,20 @@ EndGlobal
                 },
                 new[] { slnProject },
                 false);
+        }
+
+        private string GetSolutionFilePath(Project[] projects)
+        {
+            ProgramArguments programArguments = new ()
+            {
+                LaunchVisualStudio = new[] { bool.FalseString },
+            };
+
+            TestLogger testLogger = new ();
+
+            (string solutionFileFullPath, _, _, _) = SlnFile.GenerateSolutionFile(programArguments, projects, testLogger);
+
+            return solutionFileFullPath;
         }
 
         private void ValidateProjectInSolution(Action<SlnProject, ProjectInSolution> customValidator, SlnProject[] projects, bool useFolders)

--- a/src/Microsoft.VisualStudio.SlnGen/ProgramArguments.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ProgramArguments.cs
@@ -325,8 +325,23 @@ Examples:
         /// <summary>
         /// Gets a value indicating whether or not folders should be created in the solution.
         /// </summary>
+        /// <param name="slnGenFoldersPropertyValue">The SlnGenFolders property value if it exists />.</param>
         /// <returns>true if folders should be used, otherwise false.</returns>
-        public bool EnableFolders() => GetBoolean(Folders);
+        public bool EnableFolders(string slnGenFoldersPropertyValue)
+        {
+            bool? enableFolders = TryGetBoolean(Folders);
+            if (enableFolders != null)
+            {
+                return enableFolders.Value; // Use the value when available
+            }
+
+            if (bool.TryParse(slnGenFoldersPropertyValue, out bool result))
+            {
+                return result; // Fall back to the SlnGenFolders property value
+            }
+
+            return false;
+        }
 
         /// <summary>
         /// Gets the Configuration values based on what was specified as command-line arguments.
@@ -516,6 +531,21 @@ Examples:
             }
 
             return defaultValue;
+        }
+
+        private bool? TryGetBoolean(string[] values)
+        {
+            if (values == null || values.Length == 0)
+            {
+                return null;
+            }
+
+            if (bool.TryParse(values.Last(), out bool result))
+            {
+                return result;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
As discussed in #503, use the `SlnGenFolders` and `SlnGenProjectName` MSBuild properties to customize solution file names and enable folder creation in solutions.

This avoids the need for developers to both a) type `--folder true` and b) use the default `dirs.proj` (which appears in VS solution explorer as well):
```
Build started 11/15/2023 7:12:30 PM.
Searching "C:\src\test\slngen-custom\Custom" for projects
Generating solution for project "C:\src\test\slngen-custom\Custom\dirs.proj"
Loading project references...
Loaded 1 project(s) in 971ms
Generating Visual Studio solution "C:\src\test\slngen-custom\Custom\MyAwesomeComponent.sln" ...
Launching Visual Studio...

Success
    0 Warning(s)
    0 Error(s)
```

Example `dirs.proj` with the properties set:
```
<Project Sdk="Microsoft.Build.Traversal">
  <PropertyGroup>
    <SlnGenFolders>true</SlnGenFolders>
    <SlnGenProjectName>MyAwesomeComponent</SlnGenProjectName>
  </PropertyGroup>
  <ItemGroup>
    <!-- Build all projects recursively -->
    <ProjectReference Include="**/*.*proj" />
  </ItemGroup>
</Project>
```