### PR TITLE
Update InstallDir param for official yml pipeline

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -54,7 +54,7 @@ stages:
         includePreviewVersions: true
 
     - script: |
-        powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) $(DotNet9InstallArgs) -InstallDir D:\a\_work\_tool\dotnet"
+        powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) $(DotNet9InstallArgs) -InstallDir C:\ToolCache\dotnet"
         dotnet --info
       displayName: 'Install .NET $(DotNet9Version)'
 


### PR DESCRIPTION
Update `InstallDir` param for official yml pipeline, since dotnet --info is showing an alternative base path:

```
Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.20348
 OS Platform: Windows
 RID:         win-x64
 Base Path:   C:\ToolCache\dotnet\sdk\8.0.101\
```
