### PR TITLE
Use proper string comparison for directory root to capture relative paths

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
@@ -1252,6 +1252,30 @@ EndGlobal
         }
 
         [Fact]
+        public void DoNotEmitWarningForEmptyRootPathDrive()
+        {
+            TestLogger logger = new ();
+            SlnFile slnFile = new ();
+            StringBuilderTextWriter writer = new (new StringBuilder(), new List<string>());
+
+            SlnProject project = new SlnProject
+            {
+                Configurations = new[] { "Debug", "Release" },
+                FullPath = Path.Combine(TestRootPath, "ProjectA.csproj"),
+                Name = "ProjectA",
+                Platforms = new[] { "AnyCPU" },
+                ProjectGuid = new Guid("{2ACFA184-2D17-4F80-A132-EC462B48A065}"),
+                ProjectTypeGuid = new Guid("{65815BD7-8B14-4E69-8328-D5C4ED3245BE}"),
+            };
+
+            slnFile.AddProjects([project]);
+            slnFile.Save("sample.sln", writer, useFolders: true, logger, collapseFolders: true);
+
+            logger.Errors.Count.ShouldBe(0);
+            logger.Warnings.Count.ShouldBe(0);
+        }
+
+        [Fact]
         public void Save_WithSolutionItemsAddedWithParentFolder_SolutionItemsNestedInParentFolder()
         {
             // Arrange

--- a/src/Microsoft.VisualStudio.SlnGen/ExtensionMethods.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ExtensionMethods.cs
@@ -191,7 +191,7 @@ namespace Microsoft.VisualStudio.SlnGen
 
             FileInfo relativeFullPath = new FileInfo(Path.GetFullPath(relativeTo));
 
-            if (fullPath.Directory == null || relativeFullPath.Directory == null || !string.Equals(fullPath.Directory.Root.FullName, relativeFullPath.Directory.Root.FullName))
+            if (fullPath.Directory == null || relativeFullPath.Directory == null || !string.Equals(fullPath.Directory.Root.FullName, relativeFullPath.Directory.Root.FullName, StringComparison.OrdinalIgnoreCase))
             {
                 return fullPath.FullName;
             }

--- a/src/Microsoft.VisualStudio.SlnGen/SlnFile.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnFile.cs
@@ -491,7 +491,7 @@ namespace Microsoft.VisualStudio.SlnGen
                     if (hasFullPath)
                     {
                         string folderPathDrive = Path.GetPathRoot(folder.FullPath);
-                        if (!string.Equals(rootPathDrive, folderPathDrive, StringComparison.OrdinalIgnoreCase))
+                        if (!string.IsNullOrEmpty(rootPathDrive) && !string.Equals(rootPathDrive, folderPathDrive, StringComparison.OrdinalIgnoreCase))
                         {
                             useSeparateDrive = true;
                             if (!logDriveWarning)

--- a/src/Microsoft.VisualStudio.SlnGen/SlnFile.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnFile.cs
@@ -483,15 +483,18 @@ namespace Microsoft.VisualStudio.SlnGen
             if (hierarchy != null)
             {
                 bool logDriveWarning = false;
-                string rootPathDrive = Path.GetPathRoot(rootPath);
+                string rootPathDrive = Path.GetPathRoot(Path.GetFullPath(rootPath));
                 foreach (SlnFolder folder in hierarchy.Folders)
                 {
                     bool useSeparateDrive = false;
                     bool hasFullPath = !string.IsNullOrEmpty(folder.FullPath);
                     if (hasFullPath)
                     {
-                        string folderPathDrive = Path.GetPathRoot(folder.FullPath);
-                        if (!string.IsNullOrEmpty(rootPathDrive) && !string.Equals(rootPathDrive, folderPathDrive, StringComparison.OrdinalIgnoreCase))
+                        string folderPathDrive = Path.GetPathRoot(Path.GetFullPath(folder.FullPath));
+                        // Only compare path roots when root path has root directory information
+                        if (!string.IsNullOrEmpty(rootPathDrive) &&
+                            rootPathDrive.Length == folderPathDrive.Length &&
+                            !string.Equals(rootPathDrive, folderPathDrive, StringComparison.OrdinalIgnoreCase))
                         {
                             useSeparateDrive = true;
                             if (!logDriveWarning)


### PR DESCRIPTION
For directory roots that differ in casing (ex: `C:\\` vs `c:\\`), absolute instead of relative paths will appear in the solution. This change addresses that by adding a string comparison and checking the path root (drive) for the absolute root path against the folder's path root before determining whether to emit a warning (note: this will limit the scenarios where a warning is emitted).

This should help with cases where absolute paths are seen instead of relative paths, for example:
`Project("{<guid>}") = "tests", "C:\projects\slngen-test\src\core\App1\tests", "{<guid>}"
`

Should now become:
`Project("{<guid>}") = "tests", "src\core\App1\tests", "{<guid>}"
`

Addresses #578