### PR TITLE
Add MSBuild support for controlling --verbosity, --configuration, --platform and project file arguments to slngen.exe

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen/MSBuildItemNames.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/MSBuildItemNames.cs
@@ -25,6 +25,11 @@ namespace Microsoft.VisualStudio.SlnGen
         public const string SlnGenCustomProjectTypeGuid = nameof(SlnGenCustomProjectTypeGuid);
 
         /// <summary>
+        /// The name of SlnGenProjects items.
+        /// </summary>
+        public const string SlnGenProjects = nameof(SlnGenProjects);
+
+        /// <summary>
         /// The name of the SlnGenSolutionItem items.
         /// </summary>
         public const string SlnGenSolutionItem = nameof(SlnGenSolutionItem);

--- a/src/Microsoft.VisualStudio.SlnGen/MSBuildPropertyNames.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/MSBuildPropertyNames.cs
@@ -60,6 +60,11 @@ namespace Microsoft.VisualStudio.SlnGen
         public const string SlnGenBinLog = nameof(SlnGenBinLog);
 
         /// <summary>
+        /// Represents the SlnGenConfiguration property.
+        /// </summary>
+        public const string SlnGenConfiguration = nameof(SlnGenConfiguration);
+
+        /// <summary>
         /// Represents the SlnGenDebug property.
         /// </summary>
         public const string SlnGenDebug = nameof(SlnGenDebug);
@@ -101,6 +106,11 @@ namespace Microsoft.VisualStudio.SlnGen
         public const string SlnGenLoadProjects = nameof(SlnGenLoadProjects);
 
         /// <summary>
+        /// Represents the SlnGenPlatform property.
+        /// </summary>
+        public const string SlnGenPlatform = nameof(SlnGenPlatform);
+
+        /// <summary>
         /// Represents the SlnGenProjectName property.
         /// </summary>
         public const string SlnGenProjectName = nameof(SlnGenProjectName);
@@ -114,6 +124,11 @@ namespace Microsoft.VisualStudio.SlnGen
         /// Represents the name of a solution folder to place the project in.
         /// </summary>
         public const string SlnGenSolutionFolder = nameof(SlnGenSolutionFolder);
+
+        /// <summary>
+        /// Represents the SlnGenVerbosity property.
+        /// </summary>
+        public const string SlnGenVerbosity = nameof(SlnGenVerbosity);
 
         /// <summary>
         /// Represents the UsingMicrosoftNETSdk property.

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.targets
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.targets
@@ -19,17 +19,19 @@
              AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\net9.0\slngen.dll'))"
              Condition="'$(MSBuildRuntimeType)' == 'Core' And '$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.12))' == 'true'" />
 
-	<Target Name="SlnGen"
+  <Target Name="SlnGen"
           DependsOnTargets="$(SlnGenDependsOn)">
     <Error Text="SlnGen only supports .NET 8.0 or above." Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(MSBuildVersion)' &lt; '17.8.0'" />
     
     <Microsoft.VisualStudio.SlnGen.Tasks.SlnGenToolTask
       BuildingSolutionFile="$([MSBuild]::ValueOrDefault('$(BuildingSolutionFile)', 'false'))"
       Debug="$([MSBuild]::ValueOrDefault('$(SlnGenDebug)', 'true'))"
+      Verbosity="$([MSBuild]::ValueOrDefault('$(SlnGenVerbosity)', 'Normal'))"
       GlobalProperties="$(SlnGenGlobalProperties)"
       GlobalPropertiesToRemove="$(SlnGenGlobalPropertiesToRemove)"
       InheritGlobalProperties="$([MSBuild]::ValueOrDefault('$(SlnGenInheritGlobalProperties)', 'true'))"
       MSBuildBinPath="$(MSBuildBinPath)"
+	  Projects="@(SlnGenProjects)"
       ProjectFullPath="$(MSBuildProjectFullPath)" />
   </Target>
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "11.3",
+  "version": "11.4",
   "assemblyVersion": "3.0",
   "buildNumberOffset": -1,
   "publicReleaseRefSpec": [


### PR DESCRIPTION
This change gives project authors greater control over the parameters passed to `slngen.exe` by the `SlnGen` task:

| `slngen.exe` Parameter | MSBuild property/item | Default value |
|----|----|----|
| `--verbosity` | `SlnGenVerbosity` (property) | `Normal` |
| `--configuration` | `SlnGenConfiguration` (property) | Unspecified |
| `--platform` | `SlnGenPlatform` (property) | Unspecified  |
| Projects in solution | `SlnGenProjects` (item) | The project being built |

Here's an example of project authoring using the new MSBuild properties and items:

```xml
<PropertyGroup Label="SlnGen configuration properties">
  <SlnGenLaunchVisualStudio>false</SlnGenLaunchVisualStudio>
  <SlnGenSolutionFileFullPath>$(MSBuildProjectDirectory)\$(MSBuildProjectName).sln</SlnGenSolutionFileFullPath>
  <SlnGenFolders>true</SlnGenFolders>
  <SlnGenVerbosity>Minimal</SlnGenVerbosity>
  <SlnGenPlatform>AnyCPU</SlnGenPlatform>
  <SlnGenConfiguration>Debug;Release</SlnGenConfiguration>
</PropertyGroup>
<ItemGroup Label="SlnGen configuration items">
  <SlnGenProjects Include="**\*.csproj" />
  <SlnGenProjects Include="..\..\..\UnitTests\**\File*.csproj" />
</ItemGroup>
```