### PR TITLE
Sync `--launch` program argument description with README

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen/ProgramArguments.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ProgramArguments.cs
@@ -178,7 +178,7 @@ Some additional available parameters are:
             "--launch",
             CommandOptionType.MultipleValue,
             ValueName = "true|false",
-            Description = "Launch Visual Studio after generating the Solution file.  Default: true on Windows")]
+            Description = "Launch Visual Studio after generating the Solution file.  Default: true on Windows and macOS")]
         public string[] LaunchVisualStudio { get; set; }
 
         /// <summary>


### PR DESCRIPTION
For both Windows and macOS, Visual Studio is launched by default. The README correctly states this, but the program argument description wasn't updated in #492