### PR TITLE
Always honor ProjectGuid, if provided

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,7 +37,7 @@
     <PackageVersion Include="Microsoft.IO.Redist" Version="6.0.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
@@ -298,13 +298,12 @@ namespace Microsoft.VisualStudio.SlnGen
             string projectGuidValue = project.GetPropertyValue(MSBuildPropertyNames.ProjectGuid);
             bool projectGuidIsEmpty = string.IsNullOrEmpty(projectGuidValue);
 
-            // ProjectGuid is optional for SDK-style projects but required for legacy projects, if a ProjectGuid
-            // is provided it should be honored (regardless of project style) and must be valid
-            if (projectGuidIsEmpty && isUsingMicrosoftNETSdk)
+            // If a ProjectGuid is provided it should be honored (regardless of project style) and must be valid
+            if (projectGuidIsEmpty)
             {
                 projectGuid = Guid.NewGuid();
             }
-            else if (projectGuidIsEmpty || !Guid.TryParse(projectGuidValue, out projectGuid))
+            else if (!Guid.TryParse(projectGuidValue, out projectGuid))
             {
                 throw new InvalidProjectFileException(
                     projectFile: project.FullPath,

--- a/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
@@ -293,25 +293,29 @@ namespace Microsoft.VisualStudio.SlnGen
         /// <returns>The GUID of the specified project.</returns>
         internal static Guid GetProjectGuid(Project project, bool isUsingMicrosoftNETSdk)
         {
-            Guid projectGuid = Guid.NewGuid();
+            Guid projectGuid;
 
-            if (!isUsingMicrosoftNETSdk && !Guid.TryParse(project.GetPropertyValueOrDefault(MSBuildPropertyNames.ProjectGuid, projectGuid.ToString()), out projectGuid))
+            string projectGuidValue = project.GetPropertyValue(MSBuildPropertyNames.ProjectGuid);
+            bool projectGuidIsEmpty = string.IsNullOrEmpty(projectGuidValue);
+
+            // ProjectGuid is optional for SDK-style projects but required for legacy projects, if a ProjectGuid
+            // is provided it should be honored (regardless of project style) and must be valid
+            if (projectGuidIsEmpty && isUsingMicrosoftNETSdk)
             {
-                string projectGuidValue = project.GetPropertyValueOrDefault(MSBuildPropertyNames.ProjectGuid, projectGuid.ToString());
-
-                if (!Guid.TryParse(projectGuidValue, out projectGuid))
-                {
-                    throw new InvalidProjectFileException(
-                        projectFile: project.FullPath,
-                        lineNumber: 0,
-                        columnNumber: 0,
-                        endLineNumber: 0,
-                        endColumnNumber: 0,
-                        message: $"The {MSBuildPropertyNames.ProjectGuid} property value \"{projectGuidValue}\" is not a valid GUID.",
-                        errorSubcategory: null,
-                        errorCode: null,
-                        helpKeyword: null);
-                }
+                projectGuid = Guid.NewGuid();
+            }
+            else if (projectGuidIsEmpty || !Guid.TryParse(projectGuidValue, out projectGuid))
+            {
+                throw new InvalidProjectFileException(
+                    projectFile: project.FullPath,
+                    lineNumber: 0,
+                    columnNumber: 0,
+                    endLineNumber: 0,
+                    endColumnNumber: 0,
+                    message: $"The {MSBuildPropertyNames.ProjectGuid} property value \"{projectGuidValue}\" is not a valid GUID.",
+                    errorSubcategory: null,
+                    errorCode: null,
+                    helpKeyword: null);
             }
 
             return projectGuid;


### PR DESCRIPTION
GetProjectGuid will always create a new ProjectGuid for SDK-style projects, regardless of whether the project contains a ProjectGuid property or not.

This causes issues in solutions containing both SDK-style C# projects and C++/CLI projects (which are always legacy style), since the creation of a random new ProjectGuid prevents project dependencies from being correctly formed in the solution.

This PR updates GetProjectGuid to honor ProjectGuid properties defined in SDK-style projects, allowing SDK-style projects to contain manually defined ProjectGuid properties that match the Project attribute in ProjectReferences defined in legacy projects.