### PR TITLE
Publish symbols for slngen package assemblies

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -7,7 +7,6 @@ resources:
 variables:
   LogDirectory: $(Build.ArtifactStagingDirectory)/logs
   ArtifactsDirectory: artifacts
-  SymbolsDirectory: symbols
   BuildConfiguration: 'Release'
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -7,6 +7,7 @@ resources:
 variables:
   LogDirectory: $(Build.ArtifactStagingDirectory)/logs
   ArtifactsDirectory: artifacts
+  SymbolsDirectory: symbols
   BuildConfiguration: 'Release'
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'
@@ -71,3 +72,10 @@ extends:
           inputs:
             solution: '**\*.sln'
             msbuildArgs: '$(MSBuildArgs)'
+        - task: PublishSymbols@2
+          displayName: 'Publish Symbols'
+          inputs:
+            SymbolsFolder: $(Build.SourcesDirectory)/$(SymbolsDirectory)
+            SearchPattern: '**/*.pdb'
+            IndexSources: false
+            SymbolServerType: TeamServices

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -75,7 +75,6 @@ extends:
         - task: PublishSymbols@2
           displayName: 'Publish Symbols'
           inputs:
-            SymbolsFolder: $(Build.SourcesDirectory)/$(SymbolsDirectory)
-            SearchPattern: '**/*.pdb'
+            SearchPattern: '**/bin/**/*.pdb'
             IndexSources: false
             SymbolServerType: TeamServices


### PR DESCRIPTION
Add the PublishSymbols@2 task to publish symbols corresponding to the slngen package.