### PR TITLE
Add logic to support SSDT SDK project type guid

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnProjectTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnProjectTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         [InlineData(ProjectFileExtensions.VisualBasic)]
         [InlineData(ProjectFileExtensions.FSharp)]
         [InlineData(ProjectFileExtensions.Wix)]
-        [InlineData(ProjectFileExtensions.SqlServerDb)]
+        [InlineData(ProjectFileExtensions.SqlServerDbLegacy)]
         [InlineData(ProjectFileExtensions.AzureServiceFabric)]
         [InlineData(ProjectFileExtensions.Scope)]
         public void GetProjectTypeGuidLegacyProject(string extension)
@@ -124,7 +124,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         [InlineData(ProjectFileExtensions.VisualBasic)]
         [InlineData(ProjectFileExtensions.FSharp)]
         [InlineData(ProjectFileExtensions.Wix)]
-        [InlineData(ProjectFileExtensions.SqlServerDb)]
+        [InlineData(ProjectFileExtensions.SqlServerDbLegacy)]
         public void GetProjectTypeGuidSdkProject(string extension)
         {
             Dictionary<string, string> globalProperties = new Dictionary<string, string>

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnProjectTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnProjectTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         [InlineData(ProjectFileExtensions.VisualBasic)]
         [InlineData(ProjectFileExtensions.FSharp)]
         [InlineData(ProjectFileExtensions.Wix)]
-        [InlineData(ProjectFileExtensions.SqlServerDbLegacy)]
+        [InlineData(ProjectFileExtensions.SqlServerDb)]
         [InlineData(ProjectFileExtensions.AzureServiceFabric)]
         [InlineData(ProjectFileExtensions.Scope)]
         public void GetProjectTypeGuidLegacyProject(string extension)
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 case ProjectFileExtensions.VisualBasic:
                     actualProject.ProjectTypeGuid.ShouldBe(new Guid("F184B08F-C81C-45F6-A57F-5ABD9991F28F"));
                     break;
-                case ProjectFileExtensions.SqlServerDbLegacy:
+                case ProjectFileExtensions.SqlServerDb:
                     actualProject.ProjectTypeGuid.ShouldBe(new Guid("00D1A9C2-B5F0-4AF3-8072-F6C62B433612"));
                     break;
                 default:
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         [InlineData(ProjectFileExtensions.VisualBasic)]
         [InlineData(ProjectFileExtensions.FSharp)]
         [InlineData(ProjectFileExtensions.Wix)]
-        [InlineData(ProjectFileExtensions.SqlServerDbLegacy)]
+        [InlineData(ProjectFileExtensions.SqlServerDb)]
         public void GetProjectTypeGuidSdkProject(string extension)
         {
             Dictionary<string, string> globalProperties = new Dictionary<string, string>
@@ -150,8 +150,8 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                     actualProject.ProjectTypeGuid.ShouldBe(new Guid("778DAE3C-4631-46EA-AA77-85C1314464D9"));
                     break;
 
-                case ProjectFileExtensions.SqlServerDbLegacy:
-                    actualProject.ProjectTypeGuid.ShouldBe(new Guid("00D1A9C2-B5F0-4AF3-8072-F6C62B433612"));
+                case ProjectFileExtensions.SqlServerDb:
+                    actualProject.ProjectTypeGuid.ShouldBe(new Guid("42EA0DBD-9CF1-443E-919E-BE9C484E4577"));
                     break;
 
                 default:

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnProjectTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnProjectTests.cs
@@ -111,7 +111,9 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 case ProjectFileExtensions.VisualBasic:
                     actualProject.ProjectTypeGuid.ShouldBe(new Guid("F184B08F-C81C-45F6-A57F-5ABD9991F28F"));
                     break;
-
+                case ProjectFileExtensions.SqlServerDbLegacy:
+                    actualProject.ProjectTypeGuid.ShouldBe(new Guid("00D1A9C2-B5F0-4AF3-8072-F6C62B433612"));
+                    break;
                 default:
                     actualProject.ProjectTypeGuid.ShouldBe(SlnProject.KnownProjectTypeGuids[extension]);
                     break;
@@ -146,6 +148,10 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
                 case ProjectFileExtensions.VisualBasic:
                     actualProject.ProjectTypeGuid.ShouldBe(new Guid("778DAE3C-4631-46EA-AA77-85C1314464D9"));
+                    break;
+
+                case ProjectFileExtensions.SqlServerDbLegacy:
+                    actualProject.ProjectTypeGuid.ShouldBe(new Guid("00D1A9C2-B5F0-4AF3-8072-F6C62B433612"));
                     break;
 
                 default:

--- a/src/Microsoft.VisualStudio.SlnGen/ExtensionMethods.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ExtensionMethods.cs
@@ -118,6 +118,22 @@ namespace Microsoft.VisualStudio.SlnGen
         }
 
         /// <summary>
+        /// Returns true if a property value exists else returns false.
+        /// </summary>
+        /// <param name = "project" > The < see cref="Project" /> to get the property of.</param>
+        /// <param name="name">The name of the property.</param>
+        /// <returns>if the property exists return true, otherwise false.</returns>
+        public static bool DoesPropertyExist(this Project project, string name)
+        {
+            if (project.GetPropertyValue(name).Equals(String.Empty))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// Splits the current string as a semicolon delimited list of equals sign separated key/value pairs.
         /// </summary>
         /// <param name="value">The value to split.</param>

--- a/src/Microsoft.VisualStudio.SlnGen/MSBuildPropertyNames.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/MSBuildPropertyNames.cs
@@ -136,9 +136,9 @@ namespace Microsoft.VisualStudio.SlnGen
         public const string UsingMicrosoftNETSdk = nameof(UsingMicrosoftNETSdk);
 
         /// <summary>
-        /// Represents the UsingMicrosoftSQLSdk property.
+        /// Represents the NETCoreTargetsPath property.
         /// </summary>
-        public const string UsingMicrosoftSQLSdk = nameof(UsingMicrosoftSQLSdk);
+        public const string NETCoreTargetsPath = nameof(NETCoreTargetsPath);
 
         /// <summary>
         /// Represents the SlnGenIsBuildable property.

--- a/src/Microsoft.VisualStudio.SlnGen/MSBuildPropertyNames.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/MSBuildPropertyNames.cs
@@ -136,6 +136,11 @@ namespace Microsoft.VisualStudio.SlnGen
         public const string UsingMicrosoftNETSdk = nameof(UsingMicrosoftNETSdk);
 
         /// <summary>
+        /// Represents the UsingMicrosoftSQLSdk property.
+        /// </summary>
+        public const string UsingMicrosoftSQLSdk = nameof(UsingMicrosoftSQLSdk);
+
+        /// <summary>
         /// Represents the SlnGenIsBuildable property.
         /// </summary>
         public const string SlnGenIsBuildable = nameof(SlnGenIsBuildable);

--- a/src/Microsoft.VisualStudio.SlnGen/ProjectFileExtensions.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ProjectFileExtensions.cs
@@ -77,12 +77,7 @@ namespace Microsoft.VisualStudio.SlnGen
         /// <summary>
         /// SQL Server database projects (.sqlproj).
         /// </summary>
-        public const string SqlServerDbLegacy = ".sqlproj";
-
-        /// <summary>
-        /// SQL Server database projects (.sqlproj).
-        /// </summary>
-        public const string SqlServerDbSdk = ".sqlproj";
+        public const string SqlServerDb = ".sqlproj";
 
         /// <summary>
         /// Visual C++ Shared Project Items.

--- a/src/Microsoft.VisualStudio.SlnGen/ProjectFileExtensions.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ProjectFileExtensions.cs
@@ -77,7 +77,12 @@ namespace Microsoft.VisualStudio.SlnGen
         /// <summary>
         /// SQL Server database projects (.sqlproj).
         /// </summary>
-        public const string SqlServerDb = ".sqlproj";
+        public const string SqlServerDbLegacy = ".sqlproj";
+
+        /// <summary>
+        /// SQL Server database projects (.sqlproj).
+        /// </summary>
+        public const string SqlServerDbSdk = ".sqlproj";
 
         /// <summary>
         /// Visual C++ Shared Project Items.

--- a/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
@@ -35,6 +35,7 @@ namespace Microsoft.VisualStudio.SlnGen
             [string.Empty] = DefaultLegacyProjectTypeGuid,
             [ProjectFileExtensions.CSharp] = DefaultLegacyProjectTypeGuid,
             [ProjectFileExtensions.VisualBasic] = new (VisualStudioProjectTypeGuids.LegacyVisualBasicProject),
+            [ProjectFileExtensions.SqlServerDbLegacy] = new (VisualStudioProjectTypeGuids.SqlServerDbProjectLegacy),
         };
 
         /// <summary>
@@ -45,6 +46,7 @@ namespace Microsoft.VisualStudio.SlnGen
             [string.Empty] = DefaultNetSdkProjectTypeGuid,
             [ProjectFileExtensions.CSharp] = DefaultNetSdkProjectTypeGuid,
             [ProjectFileExtensions.VisualBasic] = new (VisualStudioProjectTypeGuids.NetSdkVisualBasicProject),
+            [ProjectFileExtensions.SqlServerDbSdk] = new (VisualStudioProjectTypeGuids.SqlServerDbProjectSdk),
         };
 
         /// <summary>
@@ -63,7 +65,6 @@ namespace Microsoft.VisualStudio.SlnGen
             [ProjectFileExtensions.NuProj] = new (VisualStudioProjectTypeGuids.NuProj),
             [ProjectFileExtensions.Scope] = new (VisualStudioProjectTypeGuids.ScopeProject),
             [ProjectFileExtensions.Shproj] = new (VisualStudioProjectTypeGuids.SharedProject),
-            [ProjectFileExtensions.SqlServerDbLegacy] = new (VisualStudioProjectTypeGuids.SqlServerDbProjectLegacy),
             [ProjectFileExtensions.VcxItems] = new (VisualStudioProjectTypeGuids.Cpp),
             [ProjectFileExtensions.Wap] = new (VisualStudioProjectTypeGuids.WapProject),
             [ProjectFileExtensions.Wix] = new (VisualStudioProjectTypeGuids.Wix),
@@ -160,7 +161,7 @@ namespace Microsoft.VisualStudio.SlnGen
 
             bool isUsingMicrosoftNETSdk = project.IsPropertyValueTrue(MSBuildPropertyNames.UsingMicrosoftNETSdk);
 
-            bool isUsingMicrosoftSQLSdk = project.IsPropertyValueTrue(MSBuildPropertyNames.UsingMicrosoftSQLSdk);
+            bool isUsingMicrosoftSQLSdk = project.DoesPropertyExist("NETCoreTargetsPath");
 
             string projectFileExtension = Path.GetExtension(fullPath);
 
@@ -348,13 +349,15 @@ namespace Microsoft.VisualStudio.SlnGen
 
             if (isUsingMicrosoftSQLSdk)
             {
-                projectTypeGuid = new Guid(VisualStudioProjectTypeGuids.SqlServerDbProjectSdk);
-                return projectTypeGuid;
+                if (KnownNetSdkProjectTypeGuids.TryGetValue(projectFileExtension, out projectTypeGuid))
+                {
+                    return projectTypeGuid;
+                }
             }
 
-            if (!KnownLegacyProjectTypeGuids.TryGetValue(projectFileExtension, out projectTypeGuid))
+            if (KnownLegacyProjectTypeGuids.TryGetValue(projectFileExtension, out projectTypeGuid))
             {
-                projectTypeGuid = DefaultLegacyProjectTypeGuid;
+                return projectTypeGuid;
             }
 
             return projectTypeGuid;

--- a/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.SlnGen
             [ProjectFileExtensions.NuProj] = new (VisualStudioProjectTypeGuids.NuProj),
             [ProjectFileExtensions.Scope] = new (VisualStudioProjectTypeGuids.ScopeProject),
             [ProjectFileExtensions.Shproj] = new (VisualStudioProjectTypeGuids.SharedProject),
-            [ProjectFileExtensions.SqlServerDb] = new (VisualStudioProjectTypeGuids.SqlServerDbProject),
+            [ProjectFileExtensions.SqlServerDbLegacy] = new (VisualStudioProjectTypeGuids.SqlServerDbProjectLegacy),
             [ProjectFileExtensions.VcxItems] = new (VisualStudioProjectTypeGuids.Cpp),
             [ProjectFileExtensions.Wap] = new (VisualStudioProjectTypeGuids.WapProject),
             [ProjectFileExtensions.Wix] = new (VisualStudioProjectTypeGuids.Wix),
@@ -160,6 +160,8 @@ namespace Microsoft.VisualStudio.SlnGen
 
             bool isUsingMicrosoftNETSdk = project.IsPropertyValueTrue(MSBuildPropertyNames.UsingMicrosoftNETSdk);
 
+            bool isUsingMicrosoftSQLSdk = project.IsPropertyValueTrue(MSBuildPropertyNames.UsingMicrosoftSQLSdk);
+
             string projectFileExtension = Path.GetExtension(fullPath);
 
             bool isSharedProject = string.Equals(projectFileExtension, ProjectFileExtensions.Shproj, StringComparison.Ordinal) || string.Equals(projectFileExtension, ProjectFileExtensions.VcxItems, StringComparison.Ordinal);
@@ -191,7 +193,7 @@ namespace Microsoft.VisualStudio.SlnGen
                 Name = name,
                 Platforms = GetPlatforms(project, projectFileExtension, isUsingMicrosoftNETSdk),
                 ProjectGuid = GetProjectGuid(project, isUsingMicrosoftNETSdk),
-                ProjectTypeGuid = GetProjectTypeGuid(projectFileExtension, isUsingMicrosoftNETSdk, customProjectTypeGuids),
+                ProjectTypeGuid = GetProjectTypeGuid(projectFileExtension, isUsingMicrosoftNETSdk, customProjectTypeGuids, isUsingMicrosoftSQLSdk),
                 SharedProjectItems = sharedProjectItemPaths.Any() ? sharedProjectItemPaths : Array.Empty<string>(),
                 SolutionFolder = project.GetPropertyValueOrDefault(MSBuildPropertyNames.SlnGenSolutionFolder, string.Empty),
                 IsBuildable = isBuildable,
@@ -327,7 +329,7 @@ namespace Microsoft.VisualStudio.SlnGen
         /// <param name="isUsingMicrosoftNETSdk">A value indicating whether or not the specified project is using Microsoft.NET.Sdk.</param>
         /// <param name="customProjectTypeGuids">An <see cref="IReadOnlyDictionary{String, Guid}" /> containing any user specified project type GUIDs to use.</param>
         /// <returns>A <see cref="Guid" /> representing the project type of the specified project.</returns>
-        internal static Guid GetProjectTypeGuid(string projectFileExtension, bool isUsingMicrosoftNETSdk, IReadOnlyDictionary<string, Guid> customProjectTypeGuids)
+        internal static Guid GetProjectTypeGuid(string projectFileExtension, bool isUsingMicrosoftNETSdk, IReadOnlyDictionary<string, Guid> customProjectTypeGuids, bool isUsingMicrosoftSQLSdk)
         {
             if (customProjectTypeGuids.TryGetValue(projectFileExtension, out Guid projectTypeGuid) || KnownProjectTypeGuids.TryGetValue(projectFileExtension, out projectTypeGuid))
             {
@@ -341,6 +343,12 @@ namespace Microsoft.VisualStudio.SlnGen
                     projectTypeGuid = DefaultNetSdkProjectTypeGuid;
                 }
 
+                return projectTypeGuid;
+            }
+
+            if (isUsingMicrosoftSQLSdk)
+            {
+                projectTypeGuid = new Guid(VisualStudioProjectTypeGuids.SqlServerDbProjectSdk);
                 return projectTypeGuid;
             }
 

--- a/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
@@ -357,7 +357,7 @@ namespace Microsoft.VisualStudio.SlnGen
 
             if (!KnownLegacyProjectTypeGuids.TryGetValue(projectFileExtension, out projectTypeGuid))
             {
-                return projectTypeGuid = DefaultLegacyProjectTypeGuid; ;
+                return projectTypeGuid = DefaultLegacyProjectTypeGuid;
             }
 
             return projectTypeGuid;

--- a/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.SlnGen
             [string.Empty] = DefaultLegacyProjectTypeGuid,
             [ProjectFileExtensions.CSharp] = DefaultLegacyProjectTypeGuid,
             [ProjectFileExtensions.VisualBasic] = new (VisualStudioProjectTypeGuids.LegacyVisualBasicProject),
-            [ProjectFileExtensions.SqlServerDbLegacy] = new (VisualStudioProjectTypeGuids.SqlServerDbProjectLegacy),
+            [ProjectFileExtensions.SqlServerDb] = new (VisualStudioProjectTypeGuids.SqlServerDbProjectLegacy),
         };
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.SlnGen
             [string.Empty] = DefaultNetSdkProjectTypeGuid,
             [ProjectFileExtensions.CSharp] = DefaultNetSdkProjectTypeGuid,
             [ProjectFileExtensions.VisualBasic] = new (VisualStudioProjectTypeGuids.NetSdkVisualBasicProject),
-            [ProjectFileExtensions.SqlServerDbSdk] = new (VisualStudioProjectTypeGuids.SqlServerDbProjectSdk),
+            [ProjectFileExtensions.SqlServerDb] = new (VisualStudioProjectTypeGuids.SqlServerDbProjectSdk),
         };
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
@@ -355,9 +355,9 @@ namespace Microsoft.VisualStudio.SlnGen
                 }
             }
 
-            if (KnownLegacyProjectTypeGuids.TryGetValue(projectFileExtension, out projectTypeGuid))
+            if (!KnownLegacyProjectTypeGuids.TryGetValue(projectFileExtension, out projectTypeGuid))
             {
-                return projectTypeGuid;
+                return projectTypeGuid = DefaultLegacyProjectTypeGuid; ;
             }
 
             return projectTypeGuid;

--- a/src/Microsoft.VisualStudio.SlnGen/VisualStudioProjectTypeGuids.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/VisualStudioProjectTypeGuids.cs
@@ -82,7 +82,12 @@ namespace Microsoft.VisualStudio.SlnGen
         /// <summary>
         /// SQL Server database projects (.sqlproj).
         /// </summary>
-        public const string SqlServerDbProject = "00D1A9C2-B5F0-4AF3-8072-F6C62B433612";
+        public const string SqlServerDbProjectLegacy = "00D1A9C2-B5F0-4AF3-8072-F6C62B433612";
+
+        /// <summary>
+        /// SQL Server database projects (.sqlproj).
+        /// </summary>
+        public const string SqlServerDbProjectSdk = "42EA0DBD-9CF1-443E-919E-BE9C484E4577";
 
         /// <summary>
         /// Windows Application Packaging projects (.wapproj).


### PR DESCRIPTION
Now we ship two visual studio extensions of SSDT. One of which supports SDK styled projects and another one for legacy styled projects. But file extension is still same for both kind of projects as ultimate goal is to migrate the customers to new extension. Adding logic to correctly identify guid for SSDT SDK project type.
