### PR TITLE
Pin vulnerable MessagePack package to v2.5.187

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,10 +33,11 @@
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <!-- Pinning vulnerable packages -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.2" />
+    <PackageVersion Include="MessagePack" Version="2.5.187" />
     <PackageVersion Include="Microsoft.IO.Redist" Version="6.0.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.2" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>


### PR DESCRIPTION
Due to CI pipeline failures with the following message:

`src\Microsoft.VisualStudio.SlnGen.Extension\Microsoft.VisualStudio.SlnGen.Extension.csproj(0,0): Error NU1902: Package 'MessagePack' 2.5.168 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-4qm4-8hg2-g2xm`

The `MessagePack` package was pinned to version `2.5.187`, which contains the patch.
