### PR TITLE
Target .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true'">true</ContinuousIntegrationBuild>
     <NoWarn>$(NoWarn);NETSDK1213</NoWarn>
-	<TargetDotNet10 Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</TargetDotNet10>
+    <TargetDotNet10 Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</TargetDotNet10>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <UseArtifactsOutput>false</UseArtifactsOutput>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true'">true</ContinuousIntegrationBuild>
     <NoWarn>$(NoWarn);NETSDK1213</NoWarn>
+	<TargetDotNet10 Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</TargetDotNet10>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <UseArtifactsOutput>false</UseArtifactsOutput>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <BaseArtifactsPath>$(MSBuildThisFileDirectory)artifacts</BaseArtifactsPath>
     <DefaultItemExcludes>*log</DefaultItemExcludes>
@@ -11,7 +11,6 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true'">true</ContinuousIntegrationBuild>
     <NoWarn>$(NoWarn);NETSDK1213</NoWarn>
-    <TargetDotNet9 Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</TargetDotNet9>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <UseArtifactsOutput>false</UseArtifactsOutput>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <MicrosoftBuildPackageVersion>17.12.6</MicrosoftBuildPackageVersion>
-	<MicrosoftBuildPackageVersion Condition="'$(TargetFramework)' == 'net8.0'">17.11.4</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion Condition="'$(TargetFramework)' == 'net8.0'">17.11.4</MicrosoftBuildPackageVersion>
     <SystemConfigurationConfigurationManagerPackageVersion>8.0.1</SystemConfigurationConfigurationManagerPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion>8.0.0</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion Condition="'$(TargetFramework)' == 'net472'">6.0.0</MicrosoftExtensionsFileSystemGlobbingPackageVersion>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,8 +6,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <MicrosoftBuildPackageVersion>17.11.4</MicrosoftBuildPackageVersion>
-    <MicrosoftBuildPackageVersion Condition="'$(TargetFramework)' == 'net461'">17.11.4</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.12.6</MicrosoftBuildPackageVersion>
+	<MicrosoftBuildPackageVersion Condition="'$(TargetFramework)' == 'net8.0'">17.11.4</MicrosoftBuildPackageVersion>
     <SystemConfigurationConfigurationManagerPackageVersion>8.0.1</SystemConfigurationConfigurationManagerPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion>8.0.0</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion Condition="'$(TargetFramework)' == 'net472'">6.0.0</MicrosoftExtensionsFileSystemGlobbingPackageVersion>

--- a/NuGet.config
+++ b/NuGet.config
@@ -13,7 +13,8 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
+    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget.org">
@@ -21,6 +22,9 @@
       <package pattern="*" />
     </packageSource>
     <packageSource key="dotnet10">
+      <package pattern="Microsoft.*" />
+    </packageSource>
+    <packageSource key="dotnet-tools">
       <package pattern="Microsoft.*" />
     </packageSource>
   </packageSourceMapping>

--- a/NuGet.config
+++ b/NuGet.config
@@ -12,7 +12,16 @@
   </activePackageSource>
   <packageSources>
     <clear />
-    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
 	<add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+	  <package pattern="Microsoft.*" />
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet10">
+      <package pattern="Microsoft.*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -13,11 +13,11 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-	<add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
+  <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget.org">
-	  <package pattern="Microsoft.*" />
+      <package pattern="Microsoft.*" />
       <package pattern="*" />
     </packageSource>
     <packageSource key="dotnet10">

--- a/NuGet.config
+++ b/NuGet.config
@@ -13,5 +13,6 @@
   <packageSources>
     <clear />
     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+	<add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -11,7 +11,7 @@ variables:
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'
   SignType: 'Real'
-  DotNet10InstallArgs: '--channel 10.0 --quality daily'
+  DotNet10InstallArgs: '-channel 10.0 -quality daily'
 
 trigger:
   batch: true

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -12,7 +12,7 @@ variables:
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'
   SignType: 'Real'
   # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
-  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24510.13'
+  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24564.1'
 
 trigger:
   batch: true

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -11,6 +11,9 @@ variables:
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'
   SignType: 'Real'
+  # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
+  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24510.13'
+
 trigger:
   batch: true
   branches:
@@ -65,6 +68,11 @@ extends:
           displayName: 'Install .NET 9.x'
           inputs:
             version: '9.x'
+        - script: |
+            powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) $(DotNet10InstallArgs) -InstallDir D:\a\_work\_tool\dotnet"
+            dotnet --info
+          displayName: 'Install .NET 10.x'
+
         - task: VSBuild@1
           displayName: 'Build Solution'
           inputs:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -11,8 +11,7 @@ variables:
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'
   SignType: 'Real'
-  # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
-  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24564.1'
+  DotNet10InstallArgs: '--channel 10.0 --quality daily'
 
 trigger:
   batch: true

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -11,7 +11,8 @@ variables:
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'
   SignType: 'Real'
-  DotNet10InstallArgs: '-channel 10.0 -quality daily'
+  # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
+  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24564.1'
 
 trigger:
   batch: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,8 +7,7 @@ variables:
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)"'
   SignType: 'Test'
-  # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
-  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24564.1'
+  DotNet10InstallArgs: '--channel 10.0 --quality daily'
 
 trigger:
   batch: 'true'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)"'
   SignType: 'Test'
   # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
-  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24510.13'
+  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24564.1'
 
 trigger:
   batch: 'true'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)"'
   SignType: 'Test'
-  DotNet10InstallArgs: '--channel 10.0 --quality daily'
+  DotNet10InstallArgs: '-channel 10.0 -quality daily'
 
 trigger:
   batch: 'true'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,24 @@ jobs:
     inputs:
       version: '9.x'
 
+  - script: |
+      powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) $(DotNet10InstallArgs) -InstallDir C:\hostedtoolcache\windows\dotnet"
+      dotnet --info
+    displayName: 'Install .NET 10.x (Windows)'
+    condition: eq(variables.osName, 'Windows')
+
+  - script: |
+      curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin $(DotNet10InstallArgs) --install-dir /opt/hostedtoolcache/dotnet
+      dotnet --info
+    displayName: 'Install .NET 10.x (Linux)'
+    condition: eq(variables.osName, 'Linux')
+
+  - script: |
+      curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin $(DotNet10InstallArgs) --install-dir /Users/runner/hostedtoolcache/dotnet
+      dotnet --info
+    displayName: 'Install .NET 10.x (MacOS)'
+    condition: eq(variables.osName, 'MacOS')
+
   - task: VSBuild@1
     displayName: 'Build (Visual Studio)'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,6 +90,14 @@ jobs:
       testRunTitle: '$(osName) .NET 9.0'
     condition: succeededOrFailed()
 
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests (.NET 10)'
+    inputs:
+      command: 'test'
+      arguments: '--no-restore --no-build --framework net10.0 /noautorsp $(MSBuildArgs) "/BinaryLogger:$(ArtifactsDirectoryName)/test-net10.0.binlog"'
+      testRunTitle: '$(osName) .NET 10.0'
+    condition: succeededOrFailed()
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifacts'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,8 @@ variables:
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)"'
   SignType: 'Test'
-  DotNet10InstallArgs: '-channel 10.0 -quality daily'
+  # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
+  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24564.1'
 
 trigger:
   batch: 'true'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,8 @@ variables:
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)"'
   SignType: 'Test'
+  # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
+  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24510.13'
 
 trigger:
   batch: 'true'

--- a/src/Microsoft.VisualStudio.SlnGen.Tool/Microsoft.VisualStudio.SlnGen.Tool.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen.Tool/Microsoft.VisualStudio.SlnGen.Tool.csproj
@@ -38,6 +38,14 @@
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true"
                       TargetFramework="net9.0" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.SlnGen\Microsoft.VisualStudio.SlnGen.csproj"
+                      SetTargetFramework="TargetFramework=net10.0"
+                      IncludeAssets="None"
+                      OutputItemType="SlnGenBuildOutput"
+                      PrivateAssets="All"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"
+                      TargetFramework="net10.0" />
   </ItemGroup>
   <Target Name="CopySlnGenToOutputDirectoryAndPackage"
           AfterTargets="PrepareForRun"

--- a/src/Microsoft.VisualStudio.SlnGen.Tool/Microsoft.VisualStudio.SlnGen.Tool.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen.Tool/Microsoft.VisualStudio.SlnGen.Tool.csproj
@@ -45,7 +45,8 @@
                       PrivateAssets="All"
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true"
-                      TargetFramework="net10.0" />
+                      TargetFramework="net10.0"
+                      Condition="'$(TargetDotNet10)' == 'true'" />
   </ItemGroup>
   <Target Name="CopySlnGenToOutputDirectoryAndPackage"
           AfterTargets="PrepareForRun"

--- a/src/Microsoft.VisualStudio.SlnGen.Tool/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.Tool/Program.cs
@@ -81,17 +81,11 @@ namespace Microsoft.VisualStudio.SlnGen
                     {
                         case "3":
                         case "5":
-                            Utility.WriteError(Error, "The currently configured .NET SDK {0} is not supported, SlnGen requires .NET SDK 5 or greater.", developmentEnvironment.DotNetSdkVersion);
+                        case "6":
+                        case "7":
+                            Utility.WriteError(Error, "The currently configured .NET SDK {0} is not supported, SlnGen requires .NET SDK 8 or greater.", developmentEnvironment.DotNetSdkVersion);
 
                             return (int)ExitCode.UnsupportedNETSdk;
-
-                        case "6":
-                            framework = "net6.0";
-                            break;
-
-                        case "7":
-                            framework = "net7.0";
-                            break;
 
                         case "8":
                             framework = "net8.0";
@@ -99,6 +93,10 @@ namespace Microsoft.VisualStudio.SlnGen
 
                         case "9":
                             framework = "net9.0";
+                            break;
+
+                        case "10":
+                            framework = "net10.0";
                             break;
 
                         default:

--- a/src/Microsoft.VisualStudio.SlnGen.Tool/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.Tool/Program.cs
@@ -32,6 +32,7 @@ namespace Microsoft.VisualStudio.SlnGen
             UnsupportedNETSdk = 2,
             UnknownNETSdk = 3,
             SlnGenNotFound = 4,
+            UnsupportedMSBuild = 5,
             UnhandledException = -1,
         }
 
@@ -109,16 +110,14 @@ namespace Microsoft.VisualStudio.SlnGen
                 {
                     FileVersionInfo msBuildVersionInfo = FileVersionInfo.GetVersionInfo(developmentEnvironment.MSBuildExe.FullName);
 
-                    switch (msBuildVersionInfo.FileMajorPart)
+                    if (msBuildVersionInfo.FileMajorPart < 17)
                     {
-                        case 15:
-                            framework = "net461";
-                            break;
+                        Utility.WriteError(Error, "The currently configured MSBuild {0} is not supported, SlnGen requires MSBuild 17.0 or greater.", msBuildVersionInfo.FileMajorPart);
 
-                        default:
-                            framework = "net472";
-                            break;
+                        return (int)ExitCode.UnsupportedMSBuild;
                     }
+
+                    framework = "net472";
                 }
 
                 FileInfo slnGenFileInfo = new FileInfo(Path.Combine(thisAssemblyFileInfo.DirectoryName!, "..", thisAssemblyFileInfo.DirectoryName!.EndsWith("any") ? ".." : string.Empty, "slngen", framework, useDotnet ? "slngen.dll" : "slngen.exe"));

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/Microsoft.VisualStudio.SlnGen.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/Microsoft.VisualStudio.SlnGen.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
-	<TargetFrameworks Condition="'$(TargetDotNet10)' == 'true'">$(TargetFrameworks);net10.0</TargetFrameworks>
+  <TargetFrameworks Condition="'$(TargetDotNet10)' == 'true'">$(TargetFrameworks);net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);SA1600</NoWarn>
   </PropertyGroup>

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/Microsoft.VisualStudio.SlnGen.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/Microsoft.VisualStudio.SlnGen.UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
+	<TargetFrameworks Condition="'$(TargetDotNet10)' == 'true'">$(TargetFrameworks);net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);SA1600</NoWarn>
   </PropertyGroup>

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/Microsoft.VisualStudio.SlnGen.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/Microsoft.VisualStudio.SlnGen.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
-  <TargetFrameworks Condition="'$(TargetDotNet10)' == 'true'">$(TargetFrameworks);net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetDotNet10)' == 'true'">$(TargetFrameworks);net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);SA1600</NoWarn>
   </PropertyGroup>

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/Microsoft.VisualStudio.SlnGen.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/Microsoft.VisualStudio.SlnGen.UnitTests.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);SA1600</NoWarn>
   </PropertyGroup>

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             slnFile.AddProjects(new[] { projectA, projectB, projectC, projectD, projectE, projectF, projectG });
 
-            string solutionFilePath = GetTempFileName();
+            string solutionFilePath = GetTempFileName(".sln");
 
             slnFile.Save(solutionFilePath, useFolders: false);
 
@@ -192,7 +192,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             slnFile.AddProjects(new[] { projectA, projectB, projectC, projectD, projectE });
 
-            string solutionFilePath = GetTempFileName();
+            string solutionFilePath = GetTempFileName(".sln");
 
             slnFile.Save(solutionFilePath, useFolders: false, alwaysBuild: false);
 
@@ -231,7 +231,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             slnFile.AddProjects(new[] { project });
 
-            string solutionFilePath = GetTempFileName();
+            string solutionFilePath = GetTempFileName(".sln");
 
             slnFile.Save(solutionFilePath, useFolders: false);
 
@@ -313,7 +313,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             slnFile.AddProjects(new[] { projectA, projectB, projectC, projectD });
 
-            string solutionFilePath = GetTempFileName();
+            string solutionFilePath = GetTempFileName(".sln");
 
             slnFile.Save(solutionFilePath, useFolders: false);
 
@@ -331,7 +331,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         [Fact]
         public void ExistingSolutionIsReused()
         {
-            string path = GetTempFileName();
+            string solutionFilePath = GetTempFileName(".sln");
 
             Guid projectGuid = Guid.Parse("7BE5A5CA-169D-4955-AB4D-EDDE662F4AE5");
 
@@ -355,13 +355,13 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             slnFile.AddProjects(new[] { project });
 
-            slnFile.Save(path, useFolders: false);
+            slnFile.Save(solutionFilePath, useFolders: false);
 
-            SlnFile.TryParseExistingSolution(path, out Guid solutionGuid, out _).ShouldBeTrue();
+            SlnFile.TryParseExistingSolution(solutionFilePath, out Guid solutionGuid, out _).ShouldBeTrue();
 
             solutionGuid.ShouldBe(slnFile.SolutionGuid);
 
-            SolutionFile solutionFile = SolutionFile.Parse(path);
+            SolutionFile solutionFile = SolutionFile.Parse(solutionFilePath);
 
             ProjectInSolution projectInSolution = solutionFile.ProjectsInOrder.ShouldHaveSingleItem();
 
@@ -774,7 +774,7 @@ EndGlobal
 
             string[] solutionItems = new[] { Path.Combine(root, "SubFolder1", solutionItem1Name) };
 
-            string solutionFilePath = GetTempFileName();
+            string solutionFilePath = GetTempFileName(".sln");
 
             SlnFile slnFile = new SlnFile();
 
@@ -1029,7 +1029,7 @@ EndGlobal
 
             string[] solutionItems = new[] { Path.Combine(root, "SubFolder3", solutionItem1Name) };
 
-            string solutionFilePath = GetTempFileName();
+            string solutionFilePath = GetTempFileName(".sln");
 
             SlnFile slnFile = new SlnFile();
 
@@ -1087,7 +1087,7 @@ EndGlobal
 
             string[] solutionItems = new[] { Path.Combine(root, "SubFolder3", solutionItem1Name) };
 
-            string solutionFilePath = GetTempFileName();
+            string solutionFilePath = GetTempFileName(".sln");
 
             SlnFile slnFile = new SlnFile();
 
@@ -1154,7 +1154,7 @@ EndGlobal
 
             string[] solutionItems = new[] { Path.Combine(root, "SubFolder3", solutionItem1Name) };
 
-            string solutionFilePath = GetTempFileName();
+            string solutionFilePath = GetTempFileName(".sln");
 
             SlnFile slnFile = new SlnFile();
 
@@ -1208,7 +1208,7 @@ EndGlobal
         [Fact]
         public void VisualStudioVersionIsWritten()
         {
-            string solutionFilePath = GetTempFileName();
+            string solutionFilePath = GetTempFileName(".sln");
 
             SlnFile slnFile = new SlnFile
             {
@@ -1243,7 +1243,7 @@ EndGlobal
         public void Save_WithSolutionItemsAddedToSpecificFolder_SolutionItemsExistInSpecificFolder()
         {
             // Arrange
-            string solutionFilePath = GetTempFileName();
+            string solutionFilePath = GetTempFileName(".sln");
 
             var slnFile = new SlnFile()
             {
@@ -1350,7 +1350,7 @@ EndGlobal
         public void Save_WithSolutionItemsAddedWithParentFolder_SolutionItemsNestedInParentFolder()
         {
             // Arrange
-            string solutionFilePath = GetTempFileName();
+            string solutionFilePath = GetTempFileName(".sln");
 
             var slnFile = new SlnFile()
             {
@@ -1425,7 +1425,7 @@ EndGlobal
         [InlineData(false)]
         public void SlnProject_IsBuildable_ReflectedAsProjectConfigurationInSolutionIncludeInBuild(bool isBuildable)
         {
-            string solutionFilePath = GetTempFileName();
+            string solutionFilePath = GetTempFileName(".sln");
 
             SlnFile slnFile = new SlnFile();
             SlnProject slnProject = new SlnProject
@@ -1472,7 +1472,7 @@ EndGlobal
 
         private void ValidateProjectInSolution(Action<SlnProject, ProjectInSolution> customValidator, SlnProject[] projects, bool useFolders)
         {
-            string solutionFilePath = GetTempFileName();
+            string solutionFilePath = GetTempFileName(".sln");
 
             SlnFile slnFile = new SlnFile();
 

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/TestBase.cs
@@ -15,6 +15,8 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 "8.0.0";
 #elif NET9_0 || NETFRAMEWORK
                 "9.0.0";
+#elif NET10_0 || NETFRAMEWORK
+                "10.0.0";
 #else
                 Unknown target framework
 #endif

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
+	<TargetFrameworks Condition="'$(TargetDotNet10)' == 'true'">$(TargetFrameworks);net10.0</TargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.config</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludeReferenceCopyLocalPathsInBuildOutputInPackage>true</IncludeReferenceCopyLocalPathsInBuildOutputInPackage>
     <IsTool>true</IsTool>
@@ -27,7 +28,8 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net472\MSBuild.exe" Private="false" Condition="'$(TargetFramework)' == 'net472'" />
-    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net8.0\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net10.0'" />
+    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net8.0\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'net8.0'" />
+	<Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net9.0\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" Condition="'$(TargetFramework)' == 'net472'" />

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
-	<TargetFrameworks Condition="'$(TargetDotNet10)' == 'true'">$(TargetFrameworks);net10.0</TargetFrameworks>
+  <TargetFrameworks Condition="'$(TargetDotNet10)' == 'true'">$(TargetFrameworks);net10.0</TargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.config</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludeReferenceCopyLocalPathsInBuildOutputInPackage>true</IncludeReferenceCopyLocalPathsInBuildOutputInPackage>
     <IsTool>true</IsTool>
@@ -29,7 +29,7 @@
   <ItemGroup>
     <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net472\MSBuild.exe" Private="false" Condition="'$(TargetFramework)' == 'net472'" />
     <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net8.0\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'net8.0'" />
-	<Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net9.0\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net10.0'" />
+  <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net9.0\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" Condition="'$(TargetFramework)' == 'net472'" />

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.config</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludeReferenceCopyLocalPathsInBuildOutputInPackage>true</IncludeReferenceCopyLocalPathsInBuildOutputInPackage>
     <IsTool>true</IsTool>
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net472\MSBuild.exe" Private="false" Condition="'$(TargetFramework)' == 'net472'" />
-    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net8.0\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'" />
+    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net8.0\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" Condition="'$(TargetFramework)' == 'net472'" />

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net472\MSBuild.exe" Private="false" Condition="'$(TargetFramework)' == 'net472'" />
     <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net8.0\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'net8.0'" />
-  <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net9.0\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net10.0'" />
+    <Reference Include="$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net9.0\MSBuild.dll" Private="false" Condition="'$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" Condition="'$(TargetFramework)' == 'net472'" />

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.targets
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.targets
@@ -19,6 +19,10 @@
              AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\net9.0\slngen.dll'))"
              Condition="'$(MSBuildRuntimeType)' == 'Core' And '$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.12))' == 'true'" />
 
+  <UsingTask TaskName="Microsoft.VisualStudio.SlnGen.Tasks.SlnGenToolTask"
+             AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\net10.0\slngen.dll'))"
+             Condition="'$(MSBuildRuntimeType)' == 'Core' And '$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.12))' == 'true'" />
+
   <Target Name="SlnGen"
           DependsOnTargets="$(SlnGenDependsOn)">
     <Error Text="SlnGen only supports .NET 8.0 or above." Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(MSBuildVersion)' &lt; '17.8.0'" />

--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.targets
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.targets
@@ -21,7 +21,7 @@
 
   <UsingTask TaskName="Microsoft.VisualStudio.SlnGen.Tasks.SlnGenToolTask"
              AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\net10.0\slngen.dll'))"
-             Condition="'$(MSBuildRuntimeType)' == 'Core' And '$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.12))' == 'true'" />
+             Condition="'$(MSBuildRuntimeType)' == 'Core' And '$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.13))' == 'true'" />
 
   <Target Name="SlnGen"
           DependsOnTargets="$(SlnGenDependsOn)">

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "11.4",
+  "version": "12.0",
   "assemblyVersion": "3.0",
   "buildNumberOffset": -1,
   "publicReleaseRefSpec": [


### PR DESCRIPTION
This change does the following:

* Introduces an MSBuild property, `TargetDotNet10`, which is set to `true` only in CI by default, so that when building on a machine without .NET 10 you don't get a build error.  You can manually install .NET 10 in a developer environment and set that environment variable to build and debug locally.
* Updates MSBuild package to 17.12.6 and uses the `net9.0` reference assemblies
* Adds two NuGet feeds in order to get .NET 10 packages
* Updates the build YAML to install daily builds of .NET 10 in CI.  At build time, the `runtimeconfig.json` still just points to any .NET 10 runtime so we don't have to worry about always installing the same version.
* Added logic to just fail on version of MSBuild older than 17.0 since `net461` was dropped.
* Updated tests that get solution folders under .NET 10 since those APIs in MSBuild changed and only list projects now for some reason.
* Update SlnGen version to 12.0 