### PR TITLE
Patch nuget.config package source errors for official build

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -12,6 +12,11 @@
   </activePackageSource>
   <packageSources>
     <clear />
-    <add key="slngen-aggregate" value="https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/slngen-aggregate/nuget/v3/index.json" />
+    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
+  <auditSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </auditSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -12,8 +12,9 @@
   </activePackageSource>
   <packageSources>
     <clear />
-    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
   </packageSources>
   <auditSources>
     <clear />

--- a/NuGet.config
+++ b/NuGet.config
@@ -16,6 +16,18 @@
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="dotnet-public">
+      <package pattern="Microsoft.*" />
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet-tools">
+      <package pattern="Microsoft.*" />
+    </packageSource>
+    <packageSource key="dotnet10">
+      <package pattern="Microsoft.*" />
+    </packageSource>
+  </packageSourceMapping>
   <auditSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -12,20 +12,6 @@
   </activePackageSource>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="slngen-aggregate" value="https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/slngen-aggregate/nuget/v3/index.json" />
   </packageSources>
-  <packageSourceMapping>
-    <packageSource key="nuget.org">
-      <package pattern="Microsoft.*" />
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet10">
-      <package pattern="Microsoft.*" />
-    </packageSource>
-    <packageSource key="dotnet-tools">
-      <package pattern="Microsoft.*" />
-    </packageSource>
-  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
Patch the following nuget.config related errors in the official build:
##[warning]NuGet.config - Multiple feeds declared. (https://aka.ms/cfs/nuget)
##[warning]NuGet.config - CFS0013: Package source has value that is not an Azure Artifacts feed. (https://aka.ms/cfs/nuget)