### PR TITLE
Update DotNet10InstallArgs to include later version of SDK

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -12,7 +12,7 @@ variables:
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'
   SignType: 'Real'
   # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
-  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24564.1'
+  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24571.14'
 
 trigger:
   batch: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)"'
   SignType: 'Test'
   # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
-  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24564.1'
+  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24571.14'
 
 trigger:
   batch: 'true'


### PR DESCRIPTION
Patch official build release conflicts with later version of .NET10 SDK.