### PR TITLE
Fix UsingTask order for VS 17.12

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.targets
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.targets
@@ -11,17 +11,18 @@
              AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\net472\slngen.exe'))"
              Condition="'$(MSBuildRuntimeType)' == 'Full' And '$(MSBuildToolsVersion)' == 'Current'" />
 
+  <!-- Unlike properties and items, the first UsingTask element that applies to a TaskName will be used, therefore we sort these from highest version to lowest. -->
   <UsingTask TaskName="Microsoft.VisualStudio.SlnGen.Tasks.SlnGenToolTask"
-             AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\net8.0\slngen.dll'))"
-             Condition="'$(MSBuildRuntimeType)' == 'Core' And '$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.8))' == 'true'" />
+             AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\net10.0\slngen.dll'))"
+             Condition="'$(MSBuildRuntimeType)' == 'Core' And '$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.13))' == 'true'" />
 
   <UsingTask TaskName="Microsoft.VisualStudio.SlnGen.Tasks.SlnGenToolTask"
              AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\net9.0\slngen.dll'))"
              Condition="'$(MSBuildRuntimeType)' == 'Core' And '$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.12))' == 'true'" />
 
   <UsingTask TaskName="Microsoft.VisualStudio.SlnGen.Tasks.SlnGenToolTask"
-             AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\net10.0\slngen.dll'))"
-             Condition="'$(MSBuildRuntimeType)' == 'Core' And '$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.13))' == 'true'" />
+             AssemblyFile="$([MSBuild]::ValueOrDefault('$(SlnGenAssemblyFile)', '$(MSBuildThisFileDirectory)..\tools\net8.0\slngen.dll'))"
+             Condition="'$(MSBuildRuntimeType)' == 'Core' And '$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.8))' == 'true'" />
 
   <Target Name="SlnGen"
           DependsOnTargets="$(SlnGenDependsOn)">


### PR DESCRIPTION
The MSBuild task is currently not working, and fails with runtime errors.

As per
https://learn.microsoft.com/en-us/visualstudio/msbuild/usingtask-element-msbuild?view=vs-2022:

> Unlike properties and items, the first `UsingTask` element that applies to a
> `TaskName` will be used; to override tasks you must define a new `UsingTask`
> before the existing one, or specify `Override="true"` in the new `UsingTask`.

Therefore when using Visual Studio 17.12, .NET 8 was picked instead of .NET 9, as the task/condition for .NET 8 also matched and came first.

This was broken in a69773aa152954f2484b588cd9de3d8deced463c, before that, the conditions had upper bounds.