### PR TITLE
Update .NET 10 SDK for install

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -12,7 +12,7 @@ variables:
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'
   SignType: 'Real'
   # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
-  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24571.14'
+  DotNet10InstallArgs: '-version 10.0.100-alpha.1.25074.9'
 
 trigger:
   batch: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)"'
   SignType: 'Test'
   # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
-  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24571.14'
+  DotNet10InstallArgs: '-version 10.0.100-alpha.1.25074.9'
 
 trigger:
   batch: 'true'


### PR DESCRIPTION
Updating the .NET 10 SDK version to resolve the following error which indicates the previous .NET 10 SDK version was not discoverable from the install script:
```
C:\hostedtoolcache\windows\dotnet\sdk\9.0.102\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(166,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 10.0.  Either target .NET 9.0 or lower, or use a version of the .NET SDK that supports .NET 10.0. Download the .NET SDK from https://aka.ms/dotnet/download [D:\a\1\s\src\Microsoft.VisualStudio.SlnGen\Microsoft.VisualStudio.SlnGen.csproj::TargetFramework=net10.0]
```

For future reference, the install version was determined from:
https://github.com/dotnet/sdk/blob/main/documentation/package-table.md