### PR TITLE
Update MicrosoftBuildPackageVersion to 17.14.0-preview-24624-01

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <MicrosoftBuildPackageVersion>17.12.6</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.14.0-preview-24624-01</MicrosoftBuildPackageVersion>
     <MicrosoftBuildPackageVersion Condition="'$(TargetFramework)' == 'net8.0'">17.11.4</MicrosoftBuildPackageVersion>
     <SystemConfigurationConfigurationManagerPackageVersion>9.0.0</SystemConfigurationConfigurationManagerPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion>8.0.0</MicrosoftExtensionsFileSystemGlobbingPackageVersion>


### PR DESCRIPTION
Update `MicrosoftBuildPackageVersion` property to `17.14.0-preview-24624-01` due to restore failures with `17.12.6`:
```
src\Microsoft.VisualStudio.SlnGen\Microsoft.VisualStudio.SlnGen.csproj(0,0): Error NU1701: Package 'Microsoft.Build 17.12.6' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net8.0'. This package may not be fully compatible with your project.
```

This is currently blocking package updates for this repository.

Related issue: https://github.com/NuGet/Home/issues/11564