### PR TITLE
Remove build and test jobs for linux/macOS and patch UTs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <MicrosoftBuildPackageVersion>17.12.6</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.14.0-preview-24624-01</MicrosoftBuildPackageVersion>
     <MicrosoftBuildPackageVersion Condition="'$(TargetFramework)' == 'net8.0'">17.11.4</MicrosoftBuildPackageVersion>
     <SystemConfigurationConfigurationManagerPackageVersion>9.0.0</SystemConfigurationConfigurationManagerPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion>8.0.0</MicrosoftExtensionsFileSystemGlobbingPackageVersion>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)"'
   SignType: 'Test'
   # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
-  DotNet10InstallArgs: '-version 10.0.100-alpha.1.25074.9'
+  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24571.14'
 
 trigger:
   batch: 'true'
@@ -35,12 +35,6 @@ jobs:
       Windows:
         vmImage: windows-latest
         osName: Windows
-      Linux:
-        vmImage: ubuntu-latest
-        osName: Linux
-      MacOS:
-        vmImage: macOS-latest
-        osName: MacOS
   displayName: 'Build and Test'
   pool:
     vmImage: $(vmImage)
@@ -60,18 +54,6 @@ jobs:
       dotnet --info
     displayName: 'Install .NET 10.x (Windows)'
     condition: eq(variables.osName, 'Windows')
-
-  - script: |
-      curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin $(DotNet10InstallArgs) --install-dir /opt/hostedtoolcache/dotnet
-      dotnet --info
-    displayName: 'Install .NET 10.x (Linux)'
-    condition: eq(variables.osName, 'Linux')
-
-  - script: |
-      curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin $(DotNet10InstallArgs) --install-dir /Users/runner/hostedtoolcache/dotnet
-      dotnet --info
-    displayName: 'Install .NET 10.x (MacOS)'
-    condition: eq(variables.osName, 'MacOS')
 
   - task: VSBuild@1
     displayName: 'Build (Visual Studio)'

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnFileTests.cs
@@ -1538,7 +1538,7 @@ EndGlobal
 
         private ProjectInSolution GetSolutionFolderByName(SolutionFile solutionFile, string name)
         {
-#if NET10_0_OR_GREATER
+#if NET9_0_OR_GREATER
             // In MSBuild 17.13 and above, solution folders are stored in a private property and not included in ProjectsInOrder
             PropertyInfo solutionFoldersByGuidProperty = typeof(SolutionFile).GetProperty("SolutionFoldersByGuid", BindingFlags.Instance | BindingFlags.NonPublic);
 


### PR DESCRIPTION
Remove build and test jobs for linux and macos, as windows is the priority build and test job which should run for slngen validation. This change also upgrades `Microsoft.Build` to a version >= `17.13` and updates UTs to ensure that .NET 9 SDK considers solution folders which are not stored in `ProjectsInOrder`.

Related documentation:
https://learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs