### PR TITLE
Use msbuild dll path where applicable prior to obtaining MSBuild version

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen/Program.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/Program.cs
@@ -145,7 +145,13 @@ namespace Microsoft.VisualStudio.SlnGen
 
             bool useSimpleCache = true;
 
-            var msbuildVersion = FileVersionInfo.GetVersionInfo(CurrentDevelopmentEnvironment.MSBuildExe.FullName);
+#if NETFRAMEWORK
+            string msBuildPath = CurrentDevelopmentEnvironment.MSBuildExe.FullName;
+#else
+            string msBuildPath = CurrentDevelopmentEnvironment.MSBuildDll.FullName;
+#endif
+
+            var msbuildVersion = FileVersionInfo.GetVersionInfo(msBuildPath);
 
             // Work around https://github.com/dotnet/msbuild/issues/11394 by falling back to the slower PRE cache
             // on known-affected MSBuild versions (this should be much more tightly scoped after that bug is fixed).
@@ -159,11 +165,7 @@ namespace Microsoft.VisualStudio.SlnGen
                 CacheFileEnumerations = true,
                 LoadAllFilesAsReadOnly = true,
                 UseSimpleProjectRootElementCacheConcurrency = useSimpleCache,
-#if NETFRAMEWORK
-                MSBuildExePath = CurrentDevelopmentEnvironment.MSBuildExe.FullName,
-#else
-                MSBuildExePath = CurrentDevelopmentEnvironment.MSBuildDll.FullName,
-#endif
+                MSBuildExePath = msBuildPath,
             };
 
             LoggerVerbosity verbosity = ForwardingLogger.ParseLoggerVerbosity(arguments.Verbosity?.LastOrDefault());


### PR DESCRIPTION
Addresses the assembly not found/loaded exception from #659 by using the `MSBuild.dll` as opposed to the `MSBuild.exe` path prior to obtaining the appropriate msbuild version in cases where `MSBuild.exe` may not be on PATH.

This was broken in #658, which only used the exe path to determine the appropriate MSBuild version to use prior to avoiding `SimplePRECache`.

Before change (Windows Powershell):
![image](https://github.com/user-attachments/assets/6bd731a6-6111-4d34-904e-ac4ac9732058)

After change (Windows Powershell):
![image](https://github.com/user-attachments/assets/21667fa7-8909-4f89-88ee-22cf66b192c3)