### PR TITLE
Update sdk version to 9.0.200

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "9.0.200",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   },


### PR DESCRIPTION
Update `sdk` version to `9.0.200` in global.json as an attempt to patch slngen.deps.json with missing dependencies.

In the working nuget package, slngen.deps.json had the following dependencies:
```
    ".NETCoreApp,Version=v9.0": {
      "slngen/12.0.11-xxxxxx": {
        "dependencies": {
          "EnvironmentAbstractions": "5.0.0",
          "EnvironmentAbstractions.BannedApiAnalyzer": "5.0.0",
          "McMaster.Extensions.CommandLineUtils": "4.1.1",
          "Microsoft.Build": "17.14.0-preview-24624-01",
          "Microsoft.Build.Artifacts": "6.1.48",
          "Microsoft.Build.Runtime": "17.14.0-preview-24624-01",
          "Microsoft.Build.Utilities.Core": "17.14.0-preview-24624-01",
          "Microsoft.Extensions.FileSystemGlobbing": "9.0.2",
          "Microsoft.SourceLink.GitHub": "8.0.0",
          "Microsoft.VisualStudio.Setup.Configuration.Interop": "3.12.2149",
          "Microsoft.VisualStudioEng.MicroBuild.Core": "1.0.0",
          "Nerdbank.GitVersioning": "3.6.146",
          "StyleCop.Analyzers": "1.1.118",
          "System.Configuration.ConfigurationManager": "9.0.0"
        },
        "runtime": {
          "slngen.dll": {}
        }
      },
```

In the broken nuget package, which results in the assembly not found/loaded exception for EnvironmentAbstractions.dll, slngen.deps.json appeared as the following instead:
```
    ".NETCoreApp,Version=v9.0": {
      "slngen/12.0.11": {
        "runtime": {
          "slngen.dll": {}
        }
      }
    }
```

A related issue suggests that 9.0.200 contains a potential fix for this issue, and since the official pipeline demonstrates usage of 9.0.100 in binlogs, this is updated as an attempt to enforce the official pipeline utilizes 9.0.200:
https://github.com/dotnet/sdk/issues/46247