### PR TITLE
Downgrade .NET 10 installation version for official pipeline

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -12,7 +12,7 @@ variables:
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'
   SignType: 'Real'
   # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
-  DotNet10InstallArgs: '-version 10.0.100-alpha.1.25074.9'
+  DotNet10InstallArgs: '-version 10.0.100-alpha.1.24571.14'
 
 trigger:
   batch: true


### PR DESCRIPTION
Downgrade .NET 10 installation version to ensure the version installed is the same between both the official and CI pipelines.