### PR TITLE
Append amd64 to msbuild exe path when processor arch is x64 for CoreXT

### DIFF
--- a/src/Shared/DevelopmentEnvironment.cs
+++ b/src/Shared/DevelopmentEnvironment.cs
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.SlnGen
 
                     return new DevelopmentEnvironment
                     {
-                        MSBuildExe = new FileInfo(Path.Combine(msbuildToolsPath!, "MSBuild.exe")),
+                        MSBuildExe = GetPathToMSBuildExe(new FileInfo(Path.Combine(msbuildToolsPath!, "MSBuild.exe"))),
                         IsCorext = true,
                         VisualStudio = VisualStudioConfiguration.GetLaunchableInstances()
                             .Where(i => !i.IsBuildTools && i.HasMSBuild && i.InstallationVersion.Major == visualStudioVersion.Major)


### PR DESCRIPTION
Append amd64 to msbuild exe path when processor arch is x64, similar to what is done in the non-CoreXT case. Otherwise, the 32-bit version is used instead of 64-bit, which results in an invalid assembly found.