### PR TITLE
Add RemovePackageFrameworkReferences target to avoid pulling deps

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
@@ -55,4 +55,13 @@
       <RuntimeFramework Update="@(RuntimeFramework)" Version="$(_PreviousRuntimeFramework)" />
     </ItemGroup>
   </Target>
+  <!--
+    By default, NuGet includes "framework references" so that packages can import CLR assemblies, but this kind of package does not need them added to
+    projects that reference this package.
+  -->
+  <Target Name="RemovePackageFrameworkReferences" AfterTargets="_WalkEachTargetPerFramework">
+    <ItemGroup>
+        <_FrameworkAssemblyReferences Remove="@(_FrameworkAssemblyReferences)" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
The framework assembly reference to `System.Runtime.InteropServices.RuntimeInformation` (net472) is contained in the slngen package and causing unnecessary dependencies to be pulled in.

To resolve this, add the `RemovePackageFrameworkReferences` target to remove framework references from the package.

Before change:
![image](https://github.com/user-attachments/assets/a3d17c4f-dfbd-45e9-9218-0bb3c2e5355c)

After change:
![image](https://github.com/user-attachments/assets/c323016d-794e-4773-803d-095c6f5462d8)
