### PR TITLE
Run SlnGen.exe natively on ARM64

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
+++ b/src/Microsoft.VisualStudio.SlnGen/Microsoft.VisualStudio.SlnGen.csproj
@@ -12,6 +12,9 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>false</ConcurrentGarbageCollection>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+    <PreferNativeArm64>true</PreferNativeArm64>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <PackageReference>
       <PrivateAssets>All</PrivateAssets>


### PR DESCRIPTION
Add the `PreferNativeArm64` property to Microsoft.VisualStudio.SlnGen.csproj, which enables SlnGen.exe (that targets net472) to run natively on ARM64 by embedding the following (default) Win32 manifest in the executable:

```
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
    <assemblyIdentity version="1.0.0.0" name="MyApplication.app" />
    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
        <security>
            <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
                <requestedExecutionLevel level="asInvoker" uiAccess="false" />
            </requestedPrivileges>
        </security>
    </trustInfo>
    <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
        <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2024/WindowsSettings">
            <supportedArchitectures>amd64 arm64</supportedArchitectures>
        </asmv3:windowsSettings>
    </asmv3:application>
</assembly>
```

The important part:
```
<supportedArchitectures>amd64 arm64</supportedArchitectures>
                              ^^^^^
```