### PR TITLE
Add SFPROJ extension parsing + more robust property check

### DIFF
--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/ExtensionMethodsTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/ExtensionMethodsTests.cs
@@ -2,16 +2,19 @@
 //
 // Licensed under the MIT license.
 
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Utilities.ProjectCreation;
 using Shouldly;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
 
 namespace Microsoft.VisualStudio.SlnGen.UnitTests
 {
-    public class ExtensionMethodsTests
+    public class ExtensionMethodsTests : TestBase
     {
         public static IEnumerable<object[]> GetRelativePathData()
         {
@@ -68,6 +71,50 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                     @"../../../folder1/folder2/SomeFile.txt",
                 };
             }
+        }
+
+        [Fact]
+        public void GetConditionedPropertyValuesIsEmpty()
+        {
+            Project project = ProjectCreator.Create()
+                .Save(GetTempFileName(ProjectFileExtensions.Cpp));
+            project.GetConditionedPropertyValues("Foo").ShouldBeEquivalentTo(Enumerable.Empty<string>());
+        }
+
+        [Fact]
+        public void GetConditionedPropertyValues()
+        {
+            Project project = ProjectCreator.Create()
+                .PropertyGroup(condition: " '$(Foo)' == 'Bar' ")
+                .Save(GetTempFileName(ProjectFileExtensions.FSharp));
+            project.GetConditionedPropertyValues("Foo").ToList().ShouldBeEquivalentTo(new List<string> { "Bar" });
+        }
+
+        [Fact]
+        public void GetPossiblePropertyValuesDirectly()
+        {
+            Project project = ProjectCreator.Create()
+                .Property("Foo", "Bar")
+                .Save(GetTempFileName(ProjectFileExtensions.FSharp));
+            project.GetPossiblePropertyValuesOrDefault("Foo", "Baz").ToList().ShouldBeEquivalentTo(new List<string> { "Bar" });
+        }
+
+        [Fact]
+        public void GetPossiblePropertyValuesFromConditional()
+        {
+            Project project = ProjectCreator.Create()
+                .PropertyGroup(condition: " '$(Platform)' == 'x86' ")
+                .PropertyGroup(condition: " '$(Platform)' == 'arm64' ")
+                .Save(GetTempFileName(ProjectFileExtensions.CSharp));
+            project.GetPossiblePropertyValuesOrDefault("Platform", "AnyCPU").ToList().ShouldBeEquivalentTo(new List<string> { "x86", "arm64" });
+        }
+
+        [Fact]
+        public void GetPossiblePropertyValuesReturnsDefault()
+        {
+            Project project = ProjectCreator.Create()
+                .Save(GetTempFileName(ProjectFileExtensions.FSharp));
+            project.GetPossiblePropertyValuesOrDefault("Foo", "Baz").ToList().ShouldBeEquivalentTo(new List<string> { "Baz" });
         }
 
 #if NETFRAMEWORK

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/ExtensionMethodsTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/ExtensionMethodsTests.cs
@@ -78,7 +78,8 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         {
             Project project = ProjectCreator.Create()
                 .Save(GetTempFileName(ProjectFileExtensions.Cpp));
-            project.GetConditionedPropertyValues("Foo").ShouldBeEquivalentTo(Enumerable.Empty<string>());
+            project.GetConditionedPropertyValues("Foo")
+                .ShouldBeEquivalentTo(Enumerable.Empty<string>());
         }
 
         [Fact]
@@ -87,7 +88,9 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
             Project project = ProjectCreator.Create()
                 .PropertyGroup(condition: " '$(Foo)' == 'Bar' ")
                 .Save(GetTempFileName(ProjectFileExtensions.FSharp));
-            project.GetConditionedPropertyValues("Foo").ToList().ShouldBeEquivalentTo(new List<string> { "Bar" });
+            project.GetConditionedPropertyValues("Foo")
+                .ToList()
+                .ShouldBeEquivalentTo(new List<string> { "Bar" });
         }
 
         [Fact]
@@ -96,7 +99,9 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
             Project project = ProjectCreator.Create()
                 .Property("Foo", "Bar")
                 .Save(GetTempFileName(ProjectFileExtensions.FSharp));
-            project.GetPossiblePropertyValuesOrDefault("Foo", "Baz").ToList().ShouldBeEquivalentTo(new List<string> { "Bar" });
+            project.GetPossiblePropertyValuesOrDefault("Foo", "Baz")
+                .ToList()
+                .ShouldBeEquivalentTo(new List<string> { "Bar" });
         }
 
         [Fact]
@@ -106,7 +111,9 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 .PropertyGroup(condition: " '$(Platform)' == 'x86' ")
                 .PropertyGroup(condition: " '$(Platform)' == 'arm64' ")
                 .Save(GetTempFileName(ProjectFileExtensions.CSharp));
-            project.GetPossiblePropertyValuesOrDefault("Platform", "AnyCPU").ToList().ShouldBeEquivalentTo(new List<string> { "x86", "arm64" });
+            project.GetPossiblePropertyValuesOrDefault("Platform", "AnyCPU")
+                .ToList()
+                .ShouldBeEquivalentTo(new List<string> { "x86", "arm64" });
         }
 
         [Fact]
@@ -114,7 +121,9 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         {
             Project project = ProjectCreator.Create()
                 .Save(GetTempFileName(ProjectFileExtensions.FSharp));
-            project.GetPossiblePropertyValuesOrDefault("Foo", "Baz").ToList().ShouldBeEquivalentTo(new List<string> { "Baz" });
+            project.GetPossiblePropertyValuesOrDefault("Foo", "Baz")
+                .ToList()
+                .ShouldBeEquivalentTo(new List<string> { "Baz" });
         }
 
 #if NETFRAMEWORK

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnProjectTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnProjectTests.cs
@@ -381,6 +381,50 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         }
 
         [Fact]
+        public void GetPlatformsAndConfigurationsFromServiceFabricProject()
+        {
+            Project project = ProjectCreator.Create()
+                .ItemInclude(
+                    "ProjectConfiguration",
+                    "ConfigA|PlatformA",
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["Configuration"] = "ConfigA",
+                        ["Platform"] = "PlatformA",
+                    })
+                .ItemInclude(
+                    "ProjectConfiguration",
+                    "ConfigA|PlatformB",
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["Configuration"] = "ConfigA",
+                        ["Platform"] = "PlatformB",
+                    })
+                .ItemInclude(
+                    "ProjectConfiguration",
+                    "ConfigB|PlatformA",
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["Configuration"] = "ConfigB",
+                        ["Platform"] = "PlatformA",
+                    })
+                .ItemInclude(
+                    "ProjectConfiguration",
+                    "ConfigB|PlatformB",
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["Configuration"] = "ConfigB",
+                        ["Platform"] = "PlatformB",
+                    })
+                .Save(GetTempFileName(".sfproj"));
+
+            SlnProject slnProject = SlnProject.FromProject(project, new Dictionary<string, Guid>());
+
+            slnProject.Configurations.ShouldBe(new[] { "ConfigA", "ConfigB" });
+            slnProject.Platforms.ShouldBe(new[] { "PlatformA", "PlatformB" });
+        }
+
+        [Fact]
         public void UseFileName()
         {
             CreateAndValidateProject(expectedGuid: "{DE681393-7151-459D-862C-918CCD2CB371}");

--- a/src/Microsoft.VisualStudio.SlnGen/ExtensionMethods.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ExtensionMethods.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.SlnGen
         /// <param name="project">The <see cref="Project"/> to get the property value from.</param>
         /// <param name="name">The name of the property to get the value of.</param>
         /// <returns>The values of the property if one exists, otherwise an empty Enumerable.</returns>
-        public static IEnumerable<string> GetConditionedPropertyValuesOrDefault(this Project project, string name)
+        public static IEnumerable<string> GetConditionedPropertyValues(this Project project, string name)
         {
             if (!project.ConditionedProperties.ContainsKey(name))
             {
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.SlnGen
         {
             HashSet<string> values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (string conditionPropertyValue in project.GetConditionedPropertyValuesOrDefault(name))
+            foreach (string conditionPropertyValue in project.GetConditionedPropertyValues(name))
             {
                 values.Add(conditionPropertyValue);
             }

--- a/src/Microsoft.VisualStudio.SlnGen/ExtensionMethods.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/ExtensionMethods.cs
@@ -49,13 +49,12 @@ namespace Microsoft.VisualStudio.SlnGen
         /// </summary>
         /// <param name="project">The <see cref="Project"/> to get the property value from.</param>
         /// <param name="name">The name of the property to get the value of.</param>
-        /// <param name="defaultValue">A default values comma separated to return in the case when the property has no value.</param>
-        /// <returns>The values of the property if one exists, otherwise the default value specified.</returns>
-        public static IEnumerable<string> GetConditionedPropertyValuesOrDefault(this Project project, string name, string defaultValue)
+        /// <returns>The values of the property if one exists, otherwise an empty Enumerable.</returns>
+        public static IEnumerable<string> GetConditionedPropertyValuesOrDefault(this Project project, string name)
         {
             if (!project.ConditionedProperties.ContainsKey(name))
             {
-                return defaultValue.Split(',');
+                return Enumerable.Empty<string>();
             }
 
             return project.ConditionedProperties[name];
@@ -72,7 +71,7 @@ namespace Microsoft.VisualStudio.SlnGen
         {
             HashSet<string> values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (string conditionPropertyValue in project.GetConditionedPropertyValuesOrDefault(name, defaultValue))
+            foreach (string conditionPropertyValue in project.GetConditionedPropertyValuesOrDefault(name))
             {
                 values.Add(conditionPropertyValue);
             }

--- a/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
+++ b/src/Microsoft.VisualStudio.SlnGen/SlnProject.cs
@@ -210,7 +210,7 @@ namespace Microsoft.VisualStudio.SlnGen
         /// <returns>A <see cref="IReadOnlyList{String}" /> containing the configurations that the project supports.</returns>
         internal static IReadOnlyList<string> GetConfigurations(Project project, string projectFileExtension, bool isUsingMicrosoftNETSdk)
         {
-            if (string.Equals(projectFileExtension, ".vcxproj"))
+            if (string.Equals(projectFileExtension, ProjectFileExtensions.Cpp) || string.Equals(projectFileExtension, ProjectFileExtensions.AzureServiceFabric))
             {
                 HashSet<string> items = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -449,7 +449,7 @@ namespace Microsoft.VisualStudio.SlnGen
 
         private static IReadOnlyList<string> GetPlatforms(Project project, string projectFileExtension, bool isUsingMicrosoftNETSdk)
         {
-            if (string.Equals(projectFileExtension, ".vcxproj"))
+            if (string.Equals(projectFileExtension, ProjectFileExtensions.Cpp) || string.Equals(projectFileExtension, ProjectFileExtensions.AzureServiceFabric))
             {
                 HashSet<string> items = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
## Fix: Correctly parse Configuration/Platform for Service Fabric projects

This PR addresses an issue where **Configuration** and **Platform** properties were not being correctly parsed from Service Fabric projects (`.sfproj`), leading to incomplete or incorrect solution files.

The fix is implemented in two key areas:

### 1\. Added Direct Parsing for Service Fabric Projects

Service Fabric (`.sfproj`) projects define their configurations and platforms using **ProjectConfiguration** items, a structure they share with C++ (`.vcxproj`) projects.

Sample SFPROJ properties:

```xml
<ItemGroup Label="ProjectConfigurations">
    <ProjectConfiguration Include="Debug|AnyCPU">
      <Configuration>Debug</Configuration>
      <Platform>AnyCPU</Platform>
    </ProjectConfiguration>
    <ProjectConfiguration Include="Debug|x64">
      <Configuration>Debug</Configuration>
      <Platform>x64</Platform>
    </ProjectConfiguration>
    <ProjectConfiguration Include="Release|AnyCPU">
      <Configuration>Release</Configuration>
      <Platform>AnyCPU</Platform>
    </ProjectConfiguration>
    <ProjectConfiguration Include="Release|x64">
      <Configuration>Release</Configuration>
      <Platform>x64</Platform>
    </ProjectConfiguration>
  </ItemGroup>
```

The existing logic in `SlnProject.cs` for reading these items was exclusive to `.vcxproj` files. This has been updated to also include `.sfproj` files, ensuring they are parsed using the same, correct mechanism.

Change in `SlnProject.cs`:

```diff
// Before
if (string.Equals(projectFileExtension, ProjectFileExtensions.Cpp))

// After
if (string.Equals(projectFileExtension, ProjectFileExtensions.Cpp) || string.Equals(projectFileExtension, ProjectFileExtensions.AzureServiceFabric))
```

-----

### 2\. Corrected Flawed Fallback Logic

A fallback method, `GetPossiblePropertyValuesOrDefault`, contained flawed logic that prevented it from working as intended. The method was designed to look for properties in conditioned property groups first, and then look for a direct property declaration (e.g., `<Configurations>Debug;Release</Configurations>`).

However, it would only check for the direct property if no conditioned properties were found. This PR corrects the logic to ensure that both conditioned properties and direct properties are aggregated before falling back to a default value. This makes the property discovery more robust for all project types.

-----

### Verification

New unit tests have been added to verify both aspects of this fix:

  * **GetPlatformsAndConfigurationsFromServiceFabricProject**: A new test in `SlnProjectTests.cs` that loads a sample `.sfproj` file and asserts that its Configuration and Platform values are parsed correctly from the **ProjectConfiguration** items.
  * **Tests for ExtensionMethods**: New tests have been added to `ExtensionMethodsTests.cs` to validate the corrected logic in `GetPossiblePropertyValuesOrDefault`, ensuring it correctly pulls values from direct properties, conditional properties, or returns the default value when appropriate.

