### PR TITLE
Update MSBuild package versions to fix audit warnings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,8 +6,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <MicrosoftBuildPackageVersion>17.14.8</MicrosoftBuildPackageVersion>
-    <MicrosoftBuildPackageVersion Condition="'$(TargetFramework)' == 'net8.0'">17.11.31</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>17.14.28</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion Condition="'$(TargetFramework)' == 'net8.0'">17.11.48</MicrosoftBuildPackageVersion>
     <SystemConfigurationConfigurationManagerPackageVersion>9.0.0</SystemConfigurationConfigurationManagerPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion>8.0.0</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingPackageVersion Condition="'$(TargetFramework)' == 'net472'">6.0.0</MicrosoftExtensionsFileSystemGlobbingPackageVersion>


### PR DESCRIPTION
I just happen to need to build this repo and wanted to get these fixed.  These vulnerable assemblies aren't used by SlnGen if Visual Studio is up-to-date, they just warn at restore time.

```
Package 'Microsoft.Build' 17.14.8 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3q9-fxm7-j8fq 
Package 'Microsoft.Build' 17.11.31 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3q9-fxm7-j8fq 
Package 'Microsoft.Build.Utilities.Core' 17.14.8 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3q9-fxm7-j8fq
Package 'Microsoft.Build.Utilities.Core' 17.11.31 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3q9-fxm7-j8fq
```