### PR TITLE
Temporarily revert nuget.config changes

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -32,3 +32,4 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </auditSources>
+</configuration>


### PR DESCRIPTION
Temporarily revert nuget.config changes to add nuget.org as a package source due to the following error:

`##[error]NuGet Security Analysis found 1 NuGet package configuration file in the repository which do not comply with Microsoft package feed security policies. The specific problems are listed above. Please visit https://aka.ms/cfs/nuget for more details.
`


