### PR TITLE
Downgrade Microsoft.IO.Redist to 6.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <!-- Pinning vulnerable packages -->
     <PackageVersion Include="MessagePack" Version="2.5.187" />
-    <PackageVersion Include="Microsoft.IO.Redist" Version="6.1.3" />
+    <PackageVersion Include="Microsoft.IO.Redist" Version="6.1.0" />
     <PackageVersion Include="System.Formats.Asn1" Version="9.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="9.0.0" />


### PR DESCRIPTION
Related issue: #697 

Upgrading this package to either `6.1.2` or `6.1.3` results in the following stackoverflow exception:
```
>c:\src\slngen\src\Microsoft.VisualStudio.SlnGen\bin\Debug\net472\slngen.exe
Process is terminated due to StackOverflowException
```
To mitigate, downgrade back to `6.1.0`.

Post-changes:
```
>c:\src\slngen\src\Microsoft.VisualStudio.SlnGen\bin\Debug\net472\slngen.exe
SlnGen version 12.0.30+061cd9f98b for .NET Framework
Copyright (c) Microsoft Corporation.  Licensed under the MIT license.

Build started 11/18/2025 6:44:34 PM.
```

```
>C:\src\slngen\src\Microsoft.VisualStudio.SlnGen\bin\Debug\net10.0\slngen.exe
SlnGen version 12.0.30+061cd9f98b for .NET Core
Copyright (c) Microsoft Corporation.  Licensed under the MIT license.

Build started 11/18/2025 6:52:12 PM.
```