### PR TITLE
Increase max-width of slngen documentation

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -8,4 +8,5 @@ $medium-breakpoint: 80em !default;
 
 .main-content {
     border: 10px solid red;
+    max-width: 100rem;
 }


### PR DESCRIPTION
Increase the max width of the site because it was squishing the very useful MSBuild tables.

Before:

<img width="1041" height="915" alt="image" src="https://github.com/user-attachments/assets/cd85ab9e-2bec-4b04-8dac-21ddbae42a60" />

After:

<img width="1471" height="906" alt="image" src="https://github.com/user-attachments/assets/500ce455-da71-4810-897b-fd471ae76b1d" />
