### PR TITLE
Fix ES-4.2.4 CFS network isolation

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -28,8 +28,4 @@
       <package pattern="Microsoft.*" />
     </packageSource>
   </packageSourceMapping>
-  <auditSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </auditSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,8 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <config>
-    <add key="defaultPushSource" value="https://api.nuget.org/v3/index.json" />
-  </config>
   <packageRestore>
     <add key="enabled" value="True" />
     <add key="automatic" value="True" />

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -9,7 +9,7 @@ variables:
   ArtifactsDirectory: artifacts
   BuildConfiguration: 'Release'
   BuildPlatform: 'Any CPU'
-  MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'
+  MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/p:RestoreConfigFile=$(Build.SourcesDirectory)\NuGet.config" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'
   SignType: 'Real'
   # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
   DotNet10InstallArgs: '-version 10.0.100'

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -27,6 +27,8 @@ pr: none
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     sdl:
       sbom:
         enabled: false
@@ -73,6 +75,9 @@ extends:
             powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) $(DotNet10InstallArgs) -InstallDir C:\ToolCache\dotnet"
             dotnet --info
           displayName: 'Install .NET 10.x'
+
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate Azure Artifacts feeds'
 
         - task: VSBuild@1
           displayName: 'Build Solution'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,9 @@ jobs:
     displayName: 'Install .NET 10.x (Windows)'
     condition: eq(variables.osName, 'Windows')
 
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate Azure Artifacts feeds'
+
   - task: VSBuild@1
     displayName: 'Build (Visual Studio)'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ variables:
   ArtifactsDirectoryName: 'artifacts'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'Any CPU'
-  MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)"'
+  MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/p:RestoreConfigFile=$(Build.SourcesDirectory)\NuGet.config"'
   SignType: 'Test'
   # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456
   DotNet10InstallArgs: '-version 10.0.100'


### PR DESCRIPTION
<!-- sfi-toolkit-run-id: 06947ebd-fe7f-4199-99c2-4021da36c5d7 -->
<!-- sfi-toolkit-skill: generic-remediation -->
<!-- sfi-toolkit-kpi: ES-4.2.4 -->
<!-- sfi-toolkit-version: 0.2.0-beta.4 -->

## Summary
- Enable the 1ES CFS network isolation policy in the official pipeline.
- Authenticate Azure Artifacts feeds before build steps run.
- Remove direct public NuGet references from the checked-in NuGet configuration.
- Pass the checked-in `NuGet.config` explicitly through the pipeline MSBuild arguments.

## Rationale
This follows the ES-4.2.4 CFS TSG for NuGet violations: keep package restore on Azure Artifacts feeds, avoid direct `nuget.org`/MyGet configuration, authenticate feeds before build/restore, and append `CFSClean` to the existing network isolation policy rather than replacing the current policy set.

**Open:**
- The S360 violation details were not available, so the exact flagged endpoint list was not confirmed in this PR.
- The repo still uses multiple Azure Artifacts feeds with package source mapping; owners should confirm whether these should be consolidated into a single CFS feed with upstreams.
- Repository owners should confirm the affected pipeline shows clean audited connections after the change.

## Validation
- `dotnet restore SlnGen.sln`
