### PR TITLE
Use GA .NET installs in CI

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -11,10 +11,9 @@ variables:
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/p:RestoreConfigFile=$(Build.SourcesDirectory)\NuGet.config" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'
   SignType: 'Real'
-  # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456.
-  # Sourcing the SDK version from global.json so this pipeline stays in lockstep with the
-  # repo's pinned SDK version automatically — bump global.json and CI follows.
-  DotNet10InstallArgs: '-JSonFile $(Build.SourcesDirectory)\global.json'
+  # Follow global.json's rollForward/allowPrerelease policy by installing the
+  # latest .NET 10 SDK available from the daily channel.
+  DotNet10InstallArgs: '-Channel 10.0 -Quality daily'
 
 trigger:
   batch: true

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -11,9 +11,10 @@ variables:
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/p:RestoreConfigFile=$(Build.SourcesDirectory)\NuGet.config" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'
   SignType: 'Real'
-  # Follow global.json's rollForward/allowPrerelease policy by installing the
-  # latest .NET 10 SDK available from the daily channel.
-  DotNet10InstallArgs: '-Channel 10.0 -Quality daily'
+  # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456.
+  # Sourcing the SDK version from global.json so this pipeline stays in lockstep with the
+  # repo's pinned SDK version automatically — bump global.json and CI follows.
+  DotNet10InstallArgs: '-JSonFile $(Build.SourcesDirectory)\global.json'
   DotNetInstallDirectory: '$(Agent.TempDirectory)\dotnet'
 
 trigger:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -63,15 +63,15 @@ extends:
           displayName: 'Set SignType to Real for tagged commits'
           condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
         - task: UseDotNet@2
-          displayName: 'Install .NET 8 runtime'
+          displayName: 'Install .NET 8 SDK'
           inputs:
-            packageType: 'runtime'
+            packageType: 'sdk'
             version: '8.x'
             installationPath: '$(DotNetInstallDirectory)'
         - task: UseDotNet@2
-          displayName: 'Install .NET 9 runtime'
+          displayName: 'Install .NET 9 SDK'
           inputs:
-            packageType: 'runtime'
+            packageType: 'sdk'
             version: '9.x'
             installationPath: '$(DotNetInstallDirectory)'
         - task: UseDotNet@2

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -14,6 +14,7 @@ variables:
   # Follow global.json's rollForward/allowPrerelease policy by installing the
   # latest .NET 10 SDK available from the daily channel.
   DotNet10InstallArgs: '-Channel 10.0 -Quality daily'
+  DotNetInstallDirectory: '$(Agent.TempDirectory)\dotnet'
 
 trigger:
   batch: true
@@ -68,12 +69,14 @@ extends:
           displayName: 'Install .NET 8.x'
           inputs:
             version: '8.x'
+            installationPath: '$(DotNetInstallDirectory)'
         - task: UseDotNet@2
           displayName: 'Install .NET 9.x'
           inputs:
             version: '9.x'
+            installationPath: '$(DotNetInstallDirectory)'
         - script: |
-            powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) $(DotNet10InstallArgs) -InstallDir C:\ToolCache\dotnet"
+            powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) $(DotNet10InstallArgs) -InstallDir '$(DotNetInstallDirectory)'"
             dotnet --info
           displayName: 'Install .NET 10.x'
 

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -91,6 +91,7 @@ extends:
           displayName: 'Build Solution'
           inputs:
             solution: '**\*.sln'
+            vsVersion: '18.0'
             msbuildArgs: '$(MSBuildArgs)'
         - task: PublishSymbols@2
           displayName: 'Publish Symbols'

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -11,10 +11,6 @@ variables:
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/p:RestoreConfigFile=$(Build.SourcesDirectory)\NuGet.config" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectory)\msbuild.binlog"'
   SignType: 'Real'
-  # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456.
-  # Sourcing the SDK version from global.json so this pipeline stays in lockstep with the
-  # repo's pinned SDK version automatically — bump global.json and CI follows.
-  DotNet10InstallArgs: '-JSonFile $(Build.SourcesDirectory)\global.json'
   DotNetInstallDirectory: '$(Agent.TempDirectory)\dotnet'
 
 trigger:
@@ -67,19 +63,26 @@ extends:
           displayName: 'Set SignType to Real for tagged commits'
           condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
         - task: UseDotNet@2
-          displayName: 'Install .NET 8.x'
+          displayName: 'Install .NET 8 runtime'
           inputs:
+            packageType: 'runtime'
             version: '8.x'
             installationPath: '$(DotNetInstallDirectory)'
         - task: UseDotNet@2
-          displayName: 'Install .NET 9.x'
+          displayName: 'Install .NET 9 runtime'
           inputs:
+            packageType: 'runtime'
             version: '9.x'
             installationPath: '$(DotNetInstallDirectory)'
-        - script: |
-            powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) $(DotNet10InstallArgs) -InstallDir '$(DotNetInstallDirectory)'"
+        - task: UseDotNet@2
+          displayName: 'Install .NET 10 SDK'
+          inputs:
+            packageType: 'sdk'
+            version: '10.x'
+            installationPath: '$(DotNetInstallDirectory)'
+        - powershell: |
             dotnet --info
-          displayName: 'Install .NET 10.x'
+          displayName: 'Show .NET info'
 
         - task: NuGetAuthenticate@1
           displayName: 'Authenticate Azure Artifacts feeds'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,16 +39,16 @@ jobs:
     vmImage: $(vmImage)
   steps:
   - task: UseDotNet@2
-    displayName: 'Install .NET 8 runtime'
+    displayName: 'Install .NET 8 SDK'
     inputs:
-      packageType: 'runtime'
+      packageType: 'sdk'
       version: '8.x'
       installationPath: '$(DotNetInstallDirectory)'
 
   - task: UseDotNet@2
-    displayName: 'Install .NET 9 runtime'
+    displayName: 'Install .NET 9 SDK'
     inputs:
-      packageType: 'runtime'
+      packageType: 'sdk'
       version: '9.x'
       installationPath: '$(DotNetInstallDirectory)'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,10 +7,9 @@ variables:
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/p:RestoreConfigFile=$(Build.SourcesDirectory)\NuGet.config"'
   SignType: 'Test'
-  # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456.
-  # Sourcing the SDK version from global.json so this pipeline stays in lockstep with the
-  # repo's pinned SDK version automatically — bump global.json and CI follows.
-  DotNet10InstallArgs: '-JSonFile $(Build.SourcesDirectory)\global.json'
+  # Follow global.json's rollForward/allowPrerelease policy by installing the
+  # latest .NET 10 SDK available from the daily channel.
+  DotNet10InstallArgs: '-Channel 10.0 -Quality daily'
 
 trigger:
   batch: 'true'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,9 +7,10 @@ variables:
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/p:RestoreConfigFile=$(Build.SourcesDirectory)\NuGet.config"'
   SignType: 'Test'
-  # Follow global.json's rollForward/allowPrerelease policy by installing the
-  # latest .NET 10 SDK available from the daily channel.
-  DotNet10InstallArgs: '-Channel 10.0 -Quality daily'
+  # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456.
+  # Sourcing the SDK version from global.json so this pipeline stays in lockstep with the
+  # repo's pinned SDK version automatically — bump global.json and CI follows.
+  DotNet10InstallArgs: '-JSonFile $(Build.SourcesDirectory)\global.json'
   DotNetInstallDirectory: '$(Agent.TempDirectory)\dotnet'
 
 trigger:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,10 +7,6 @@ variables:
   BuildPlatform: 'Any CPU'
   MSBuildArgs: '"/Property:Platform=$(BuildPlatform);Configuration=$(BuildConfiguration)" "/p:RestoreConfigFile=$(Build.SourcesDirectory)\NuGet.config"'
   SignType: 'Test'
-  # Not using "--channel 10.0 --quality daily", see https://github.com/microsoft/slngen/issues/456.
-  # Sourcing the SDK version from global.json so this pipeline stays in lockstep with the
-  # repo's pinned SDK version automatically — bump global.json and CI follows.
-  DotNet10InstallArgs: '-JSonFile $(Build.SourcesDirectory)\global.json'
   DotNetInstallDirectory: '$(Agent.TempDirectory)\dotnet'
 
 trigger:
@@ -43,21 +39,29 @@ jobs:
     vmImage: $(vmImage)
   steps:
   - task: UseDotNet@2
-    displayName: 'Install .NET 8.x'
+    displayName: 'Install .NET 8 runtime'
     inputs:
+      packageType: 'runtime'
       version: '8.x'
       installationPath: '$(DotNetInstallDirectory)'
 
   - task: UseDotNet@2
-    displayName: 'Install .NET 9.x'
+    displayName: 'Install .NET 9 runtime'
     inputs:
+      packageType: 'runtime'
       version: '9.x'
       installationPath: '$(DotNetInstallDirectory)'
 
-  - script: |
-      powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) $(DotNet10InstallArgs) -InstallDir '$(DotNetInstallDirectory)'"
+  - task: UseDotNet@2
+    displayName: 'Install .NET 10 SDK'
+    inputs:
+      packageType: 'sdk'
+      version: '10.x'
+      installationPath: '$(DotNetInstallDirectory)'
+
+  - powershell: |
       dotnet --info
-    displayName: 'Install .NET 10.x (Windows)'
+    displayName: 'Show .NET info'
     condition: eq(variables.osName, 'Windows')
 
   - task: NuGetAuthenticate@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
   strategy:
     matrix:
       Windows:
-        vmImage: windows-latest
+        vmImage: windows-2025-vs2026
         osName: Windows
   displayName: 'Build and Test'
   pool:
@@ -70,6 +70,7 @@ jobs:
   - task: VSBuild@1
     displayName: 'Build (Visual Studio)'
     inputs:
+      vsVersion: '18.0'
       msbuildArgs: '$(MSBuildArgs) "/BinaryLogger:$(ArtifactsDirectoryName)/build.binlog"'
     condition: eq(variables.osName, 'Windows')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ variables:
   # Follow global.json's rollForward/allowPrerelease policy by installing the
   # latest .NET 10 SDK available from the daily channel.
   DotNet10InstallArgs: '-Channel 10.0 -Quality daily'
+  DotNetInstallDirectory: '$(Agent.TempDirectory)\dotnet'
 
 trigger:
   batch: 'true'
@@ -44,14 +45,16 @@ jobs:
     displayName: 'Install .NET 8.x'
     inputs:
       version: '8.x'
+      installationPath: '$(DotNetInstallDirectory)'
 
   - task: UseDotNet@2
     displayName: 'Install .NET 9.x'
     inputs:
       version: '9.x'
+      installationPath: '$(DotNetInstallDirectory)'
 
   - script: |
-      powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) $(DotNet10InstallArgs) -InstallDir C:\hostedtoolcache\windows\dotnet"
+      powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) $(DotNet10InstallArgs) -InstallDir '$(DotNetInstallDirectory)'"
       dotnet --info
     displayName: 'Install .NET 10.x (Windows)'
     condition: eq(variables.osName, 'Windows')

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnGenTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnGenTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
         [Fact]
         public void InsertsVSVersion()
         {
-            string requestedVSVersion = "17";
+            string requestedVSVersion = "18";
             Dictionary<string, string> globalProperties = new Dictionary<string, string>
             {
                 [MSBuildPropertyNames.DesignTimeBuild] = bool.TrueString,

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnGenTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnGenTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 .Save()
                 .TryBuild("SlnGen", globalProperties, out bool result, out BuildOutput buildOutput, out _);
 
-            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+            result.ShouldBeTrue(GetBuildOutputLog(buildOutput));
 
             string expectedSolutionFilePath = Path.ChangeExtension(mainProject.FullPath, ".sln");
 
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                     projectC,
                     projectD,
                 },
-                buildOutput.GetConsoleLog());
+                GetBuildOutputLog(buildOutput));
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 .Save()
                 .TryBuild("SlnGen", globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs);
 
-            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+            result.ShouldBeTrue(GetBuildOutputLog(buildOutput));
 
             KeyValuePair<string, TargetResult> targetOutput = targetOutputs.ShouldHaveSingleItem();
 
@@ -181,7 +181,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 .Save()
                 .TryBuild("SlnGen", globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs);
 
-            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+            result.ShouldBeTrue(GetBuildOutputLog(buildOutput));
 
             KeyValuePair<string, TargetResult> targetOutput = targetOutputs.ShouldHaveSingleItem();
 
@@ -194,6 +194,22 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
             string[] solutionLines = File.ReadAllLines(expected.FullName);
             solutionLines.ShouldContain($"# Visual Studio Version {requestedVSVersion}");
             solutionLines.ShouldContain(line => line.StartsWith($"VisualStudioVersion = {requestedVSVersion}"));
+        }
+
+        private static string GetBuildOutputLog(BuildOutput buildOutput)
+        {
+            try
+            {
+                return buildOutput.GetConsoleLog();
+            }
+            catch (NullReferenceException ex)
+            {
+                string errorsAndWarnings = string.Join(
+                    Environment.NewLine,
+                    buildOutput.Errors.Concat(buildOutput.Warnings));
+
+                return string.IsNullOrWhiteSpace(errorsAndWarnings) ? ex.ToString() : errorsAndWarnings;
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnGenTests.cs
+++ b/src/Microsoft.VisualStudio.SlnGen.UnitTests/SlnGenTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 .Save()
                 .TryBuild("SlnGen", globalProperties, out bool result, out BuildOutput buildOutput, out _);
 
-            result.ShouldBeTrue(GetBuildOutputLog(buildOutput));
+            result.ShouldBeTrue(result ? null : GetBuildOutputLog(buildOutput));
 
             string expectedSolutionFilePath = Path.ChangeExtension(mainProject.FullPath, ".sln");
 
@@ -85,17 +85,17 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
 
             SolutionFile solutionFile = SolutionFile.Parse(expectedSolutionFilePath);
 
-            solutionFile.ProjectsInOrder.Select(i => Path.GetFullPath(i.AbsolutePath))
-                .ShouldBe(
-                new string[]
-                {
-                    mainProject,
-                    projectA,
-                    projectB,
-                    projectC,
-                    projectD,
-                },
-                GetBuildOutputLog(buildOutput));
+            string[] actualProjects = solutionFile.ProjectsInOrder.Select(i => Path.GetFullPath(i.AbsolutePath)).ToArray();
+            string[] expectedProjects =
+            {
+                mainProject,
+                projectA,
+                projectB,
+                projectC,
+                projectD,
+            };
+
+            actualProjects.ShouldBe(expectedProjects, actualProjects.SequenceEqual(expectedProjects) ? null : GetBuildOutputLog(buildOutput));
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 .Save()
                 .TryBuild("SlnGen", globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs);
 
-            result.ShouldBeTrue(GetBuildOutputLog(buildOutput));
+            result.ShouldBeTrue(result ? null : GetBuildOutputLog(buildOutput));
 
             KeyValuePair<string, TargetResult> targetOutput = targetOutputs.ShouldHaveSingleItem();
 
@@ -181,7 +181,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
                 .Save()
                 .TryBuild("SlnGen", globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs);
 
-            result.ShouldBeTrue(GetBuildOutputLog(buildOutput));
+            result.ShouldBeTrue(result ? null : GetBuildOutputLog(buildOutput));
 
             KeyValuePair<string, TargetResult> targetOutput = targetOutputs.ShouldHaveSingleItem();
 
@@ -204,6 +204,7 @@ namespace Microsoft.VisualStudio.SlnGen.UnitTests
             }
             catch (NullReferenceException ex)
             {
+                // MSBuild 18 can throw while replaying captured events through ParallelConsoleLogger.
                 string errorsAndWarnings = string.Join(
                     Environment.NewLine,
                     buildOutput.Errors.Concat(buildOutput.Warnings));


### PR DESCRIPTION
## Summary
- update CI for SFI so the build installs the latest released .NET SDKs instead of relying on stale hosted-image versions
- use `UseDotNet@2` wildcard installs for .NET 8, .NET 9, and .NET 10 SDKs, floating to released GA versions while excluding previews by default
- install SDKs into `$(Agent.TempDirectory)\dotnet` to avoid hosted tool-cache copy/EIO failures
- run public CI on the VS2026 hosted image and request `vsVersion: 18.0` so the latest GA .NET 10 SDK is loaded by MSBuild 18
- update the net472 SlnGen integration test expectations for the VS2026/MSBuild 18 environment

## Notes
- This is for SFI compliance: CI should continuously use the latest compatible released .NET SDKs
- `global.json` remains the repo's SDK security floor; CI installs the latest compatible GA SDKs for the build

## Validation
- clean restore with GA .NET 10 SDK succeeded locally
- Visual Studio MSBuild solution build succeeded locally