### PR TITLE
Use VS stable pool for official builds

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -32,7 +32,7 @@ extends:
       sbom:
         enabled: false
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
       demands:
       - msbuild
       - visualstudio
@@ -44,7 +44,7 @@ extends:
       - job: Build
         displayName: 'Build'
         pool:
-          name: 'VSEngSS-MicroBuild2022-1ES'
+          name: 'VSEng-MicroBuildVSStable'
         templateContext:
           mb:
             signing:


### PR DESCRIPTION
## Summary
- Move the official MicroBuild pipeline from the VS2022 pool to `VSEng-MicroBuildVSStable`.
- Keep the existing floating `.NET 10.x` SDK install while ensuring `VSBuild@1` runs on a pool intended for VS 2026 / MSBuild 18.

## Evidence
- [MSBuildSdks PR microsoft/MSBuildSdks#663](https://github.com/microsoft/MSBuildSdks/pull/663) migrated official builds to `VSEng-MicroBuildVSStable` and describes it as “VS 2026 agents”.
- [VSIDEConEx.IdentityService `nodeJob.yml`](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VSIDEConEx.IdentityService?path=/azure-pipelines/nodeJob.yml&version=GBmain&line=86&lineEnd=91&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents) says: `The CI pool VSEng-MicroBuildVSStable only ships Visual Studio 18.x (VS 2026)`.
- [vs-code-coverage `azure-pipelines.yml`](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/vs-code-coverage?path=/azure-pipelines.yml&version=GBmain&line=99&lineEnd=102&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents) uses `VSEng-MicroBuildVSStable` with `ImageOverride -equals server2025-microbuildVSStable`.
- [VSAzureImages stable VS Server 2025 image](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VSAzureImages?path=/ServerImages/stable/vs-latest-ent-ws2025-datacenter-azure-gen2.bicep&version=GBmain&line=5&lineEnd=20&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents) uses the stable VS image artifact module, and [that module](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VSAzureImages?path=/bicepmodules/common-devBoxArtifacts-stable.bicep&version=GBmain&line=51&lineEnd=56&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents) installs from `https://aka.ms/vs/stable/vs_Enterprise.exe`.
- [`aka.ms/vs/18/stable` channel manifest](https://download.visualstudio.microsoft.com/download/pr/471ad3d6-cb2b-4d53-8edf-a9eeade096a5/b9b202f02886023f13e3ae80d3f71d626b86b00380478dfdb86dceac6569d527/VisualStudio.18.Release.chman) currently reports Visual Studio 18.6.2 and `Microsoft.Build` 18.6.3.

## Validation
- Built locally with MSBuild 18.